### PR TITLE
SONARFBUGS-8 Findbugs analysis should not fail if only package-info.java files are analysed.

### DIFF
--- a/src/main/java/org/sonar/plugins/findbugs/AnalysisNotNeededException.java
+++ b/src/main/java/org/sonar/plugins/findbugs/AnalysisNotNeededException.java
@@ -1,0 +1,44 @@
+/*
+ * SonarQube Findbugs Plugin
+ * Copyright (C) 2012 SonarSource
+ * dev@sonar.codehaus.org
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
+ */
+package org.sonar.plugins.findbugs;
+
+/**
+ * Exception thrown when configuring Findbugs, and there are non classes to analyse.
+ * This can happen then there are package-info.java files, that should be analysed by source code analysis tools,
+ * but that does not generate any bytocode for Findbugs to analyze.
+ */
+public class AnalysisNotNeededException extends Exception {
+
+  public AnalysisNotNeededException() {
+  }
+
+  public AnalysisNotNeededException(String message) {
+    super(message);
+  }
+
+  public AnalysisNotNeededException(String message, Throwable cause) {
+    super(message, cause);
+  }
+
+  public AnalysisNotNeededException(Throwable cause) {
+    super(cause);
+  }
+
+}

--- a/src/main/java/org/sonar/plugins/findbugs/FindbugsConfiguration.java
+++ b/src/main/java/org/sonar/plugins/findbugs/FindbugsConfiguration.java
@@ -30,6 +30,9 @@ import org.sonar.api.BatchExtension;
 import org.sonar.api.CoreProperties;
 import org.sonar.api.PropertyType;
 import org.sonar.api.batch.ProjectClasspath;
+import org.sonar.api.batch.fs.FilePredicates;
+import org.sonar.api.batch.fs.FileSystem;
+import org.sonar.api.batch.fs.InputFile;
 import org.sonar.api.config.PropertyDefinition;
 import org.sonar.api.config.Settings;
 import org.sonar.api.profiles.RulesProfile;
@@ -48,17 +51,18 @@ import java.util.List;
 
 
 public class FindbugsConfiguration implements BatchExtension {
-
-  private final ModuleFileSystem fileSystem;
+  private final FileSystem fileSystem;
+  private final ModuleFileSystem moduleFileSystem;
   private final Settings settings;
   private final RulesProfile profile;
   private final FindbugsProfileExporter exporter;
   private final ProjectClasspath projectClasspath;
   private final JavaResourceLocator javaResourceLocator;
 
-  public FindbugsConfiguration(ModuleFileSystem fileSystem, Settings settings, RulesProfile profile, FindbugsProfileExporter exporter, ProjectClasspath classpath,
+  public FindbugsConfiguration(FileSystem fileSystem, ModuleFileSystem moduleFileSystem, Settings settings, RulesProfile profile, FindbugsProfileExporter exporter, ProjectClasspath classpath,
                                JavaResourceLocator javaResourceLocator) {
     this.fileSystem = fileSystem;
+    this.moduleFileSystem = moduleFileSystem;
     this.settings = settings;
     this.profile = profile;
     this.exporter = exporter;
@@ -67,12 +71,12 @@ public class FindbugsConfiguration implements BatchExtension {
   }
 
   public File getTargetXMLReport() {
-    return new File(fileSystem.workingDir(), "findbugs-result.xml");
+    return new File(moduleFileSystem.workingDir(), "findbugs-result.xml");
   }
 
-  public edu.umd.cs.findbugs.Project getFindbugsProject() throws IOException {
+  public edu.umd.cs.findbugs.Project getFindbugsProject() throws IOException, AnalysisNotNeededException {
     edu.umd.cs.findbugs.Project findbugsProject = new edu.umd.cs.findbugs.Project();
-    for (File dir : fileSystem.sourceDirs()) {
+    for (File dir : moduleFileSystem.sourceDirs()) {
       findbugsProject.addSourceDir(dir.getAbsolutePath());
     }
 
@@ -82,12 +86,17 @@ public class FindbugsConfiguration implements BatchExtension {
     }
 
     if (classFilesToAnalyze.isEmpty()) {
-      throw new SonarException("Findbugs needs sources to be compiled. "
-          + "Please build project before executing sonar and check the location of compiled classes.");
+      FilePredicates p = fileSystem.predicates();
+      if (fileSystem.hasFiles(p.and(p.hasLanguage("java"), p.hasType(InputFile.Type.MAIN), p.doesNotMatchPathPattern("**/package-info.java")))) {
+        throw new SonarException("Findbugs needs sources to be compiled. "
+            + "Please build project before executing sonar and check the location of compiled classes.");
+      } else {
+        throw new AnalysisNotNeededException();
+      }
     }
 
     for (File file : projectClasspath.getElements()) {
-      findbugsProject.addAuxClasspathEntry(file.getAbsolutePath());
+      findbugsProject.addAuxClasspathEntry(file.getPath());
     }
     copyLibs();
     if (annotationsLib != null) {
@@ -95,7 +104,7 @@ public class FindbugsConfiguration implements BatchExtension {
       findbugsProject.addAuxClasspathEntry(annotationsLib.getAbsolutePath());
       findbugsProject.addAuxClasspathEntry(jsr305Lib.getAbsolutePath());
     }
-    findbugsProject.setCurrentWorkingDirectory(fileSystem.buildDir());
+    findbugsProject.setCurrentWorkingDirectory(moduleFileSystem.buildDir());
     return findbugsProject;
   }
 
@@ -103,7 +112,7 @@ public class FindbugsConfiguration implements BatchExtension {
   File saveIncludeConfigXml() throws IOException {
     StringWriter conf = new StringWriter();
     exporter.exportProfile(profile, conf);
-    File file = new File(fileSystem.workingDir(), "findbugs-include.xml");
+    File file = new File(moduleFileSystem.workingDir(), "findbugs-include.xml");
     FileUtils.write(file, conf.toString(), CharEncoding.UTF_8);
     return file;
   }
@@ -116,7 +125,7 @@ public class FindbugsConfiguration implements BatchExtension {
     for (String excludesFilterPath : filters) {
       excludesFilterPath = StringUtils.trim(excludesFilterPath);
       if (StringUtils.isNotBlank(excludesFilterPath)) {
-        result.add(pathResolver.relativeFile(fileSystem.baseDir(), excludesFilterPath));
+        result.add(pathResolver.relativeFile(moduleFileSystem.baseDir(), excludesFilterPath));
       }
     }
     return result;
@@ -169,7 +178,7 @@ public class FindbugsConfiguration implements BatchExtension {
     InputStream input = null;
     try {
       input = getClass().getResourceAsStream(name);
-      File dir = new File(fileSystem.workingDir(), "findbugs");
+      File dir = new File(moduleFileSystem.workingDir(), "findbugs");
       FileUtils.forceMkdir(dir);
       File target = new File(dir, name);
       FileUtils.copyInputStreamToFile(input, target);

--- a/src/main/java/org/sonar/plugins/findbugs/FindbugsExecutor.java
+++ b/src/main/java/org/sonar/plugins/findbugs/FindbugsExecutor.java
@@ -50,6 +50,7 @@ import java.net.URISyntaxException;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.List;
@@ -148,6 +149,10 @@ public class FindbugsExecutor implements BatchExtension {
       profiler.stop();
 
       return toReportedBugs(xmlBugReporter.getBugCollection());
+    } catch (AnalysisNotNeededException e) {
+      LOG.info("There are no class files to analyze. Skipping Findbugs analysis");
+      profiler.stop();
+      return Collections.emptyList();
     } catch (TimeoutException e) {
       throw new SonarException("Can not execute Findbugs with a timeout threshold value of " + configuration.getTimeout() + " milliseconds", e);
     } catch (Exception e) {

--- a/src/test/java/org/sonar/plugins/findbugs/FindbugsExecutorTest.java
+++ b/src/test/java/org/sonar/plugins/findbugs/FindbugsExecutorTest.java
@@ -25,6 +25,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import org.sonar.api.CoreProperties;
+import org.sonar.api.batch.fs.FileSystem;
 import org.sonar.api.config.Settings;
 import org.sonar.api.scan.filesystem.ModuleFileSystem;
 import org.sonar.api.utils.SonarException;
@@ -86,10 +87,11 @@ public class FindbugsExecutorTest {
 
   @Test(expected = SonarException.class)
   public void shoulFailIfNoCompiledClasses() throws Exception {
-    ModuleFileSystem fs = mock(ModuleFileSystem.class);
+    FileSystem fs = mock(FileSystem.class);
+    ModuleFileSystem mfs = mock(ModuleFileSystem.class);
     Settings settings = new Settings();
     settings.setProperty(CoreProperties.CORE_VIOLATION_LOCALE_PROPERTY, Locale.getDefault().getDisplayName());
-    FindbugsConfiguration conf = new FindbugsConfiguration(fs, settings, null, null, null, null);
+    FindbugsConfiguration conf = new FindbugsConfiguration(fs, mfs, settings, null, null, null, null);
 
     new FindbugsExecutor(conf).execute();
   }


### PR DESCRIPTION
This is the same as https://github.com/SonarSource/sonar-java/pull/12, for the new findbugs repository.
I just wanted to make sure the previous PR still works. It does.

Intercepts the use case where only package-info.java files (which do not generate any class to be analyzed by Findbugs) are present in the source folders.
