### PR TITLE
SONARFBUGS-7 Upgrade to findbugs 3.0.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,9 @@
   </scm>
 
   <properties>
-    <findbugs.version>2.0.3</findbugs.version>
+    <findbugs.version>3.0.0</findbugs.version>
+    <jdk.min.version>1.7</jdk.min.version>
+
     <sonar.version>4.2</sonar.version>
     <!-- once java 2.4 is released only one property is required -->
     <sonar-java.version>2.3</sonar-java.version>
@@ -246,8 +248,8 @@
             <configuration>
               <rules>
                 <requireFilesSize>
-                  <maxsize>5800000</maxsize>
-                  <minsize>4700000</minsize>
+                  <maxsize>6800000</maxsize>
+                  <minsize>5800000</minsize>
                   <files>
                     <file>${project.build.directory}/${project.build.finalName}.jar</file>
                   </files>

--- a/src/main/resources/org/sonar/l10n/findbugs.properties
+++ b/src/main/resources/org/sonar/l10n/findbugs.properties
@@ -417,3 +417,7 @@ rule.findbugs.DLS_DEAD_LOCAL_INCREMENT_IN_RETURN.name=Useless increment in retur
 rule.findbugs.DM_BOXED_PRIMITIVE_FOR_PARSING.name=Boxing/unboxing to parse a primitive
 rule.findbugs.NP_METHOD_RETURN_RELAXING_ANNOTATION.name=Method relaxes nullness annotation on return value
 rule.findbugs.NP_METHOD_PARAMETER_TIGHTENS_ANNOTATION.name=Method tightens nullness annotation on parameter
+rule.findbugs.NP_OPTIONAL_RETURN_NULL=Method with Optional return type returns explicit null
+rule.findbugs.IIO_INEFFICIENT_INDEX_OF=Inefficient use of String.indexOf(String)
+rule.findbugs.IIO_INEFFICIENT_LAST_INDEX_OF=Inefficient use of String.lastIndexOf(String)
+rule.findbugs.CNT_ROUGH_CONSTANT_VALUE=Rough value of known constant found

--- a/src/main/resources/org/sonar/l10n/findbugs/rules/findbugs/CNT_ROUGH_CONSTANT_VALUE.html
+++ b/src/main/resources/org/sonar/l10n/findbugs/rules/findbugs/CNT_ROUGH_CONSTANT_VALUE.html
@@ -1,0 +1,1 @@
+<p>It's recommended to use the predefined library constant for code clarity and better precision.</p>

--- a/src/main/resources/org/sonar/l10n/findbugs/rules/findbugs/IIO_INEFFICIENT_INDEX_OF.html
+++ b/src/main/resources/org/sonar/l10n/findbugs/rules/findbugs/IIO_INEFFICIENT_INDEX_OF.html
@@ -1,0 +1,1 @@
+<p>This code passes a constant string of length 1 to String.indexOf(). It is more efficient to use the integer implementations of String.indexOf(). f. e. call myString.indexOf('.') instead of myString.indexOf(".")</p>

--- a/src/main/resources/org/sonar/l10n/findbugs/rules/findbugs/IIO_INEFFICIENT_LAST_INDEX_OF.html
+++ b/src/main/resources/org/sonar/l10n/findbugs/rules/findbugs/IIO_INEFFICIENT_LAST_INDEX_OF.html
@@ -1,0 +1,1 @@
+<p>This code passes a constant string of length 1 to String.lastIndexOf(). It is more efficient to use the integer implementations of String.lastIndexOf(). f. e. call myString.lastIndexOf('.') instead of myString.lastIndexOf(".")</p>

--- a/src/main/resources/org/sonar/l10n/findbugs/rules/findbugs/NP_OPTIONAL_RETURN_NULL.html
+++ b/src/main/resources/org/sonar/l10n/findbugs/rules/findbugs/NP_OPTIONAL_RETURN_NULL.html
@@ -1,0 +1,1 @@
+<p>The usage of Optional return type always mean that explicit null returns were not desired by design. Returning a null value in such case is a contract violation and will most likely break clients code.</p>

--- a/src/main/resources/org/sonar/plugins/findbugs/rules.xml
+++ b/src/main/resources/org/sonar/plugins/findbugs/rules.xml
@@ -2540,4 +2540,28 @@
     <configKey><![CDATA[NP_METHOD_PARAMETER_TIGHTENS_ANNOTATION]]></configKey>
   </rule>
 
+  <rule key="NP_OPTIONAL_RETURN_NULL">
+    <priority>MAJOR</priority>
+    <name><![CDATA[Method with Optional return type returns explicit null]]></name>
+    <configKey><![CDATA[NP_OPTIONAL_RETURN_NULL]]></configKey>
+  </rule>
+
+  <rule key="IIO_INEFFICIENT_INDEX_OF">
+    <priority>MAJOR</priority>
+    <name><![CDATA[Inefficient use of String.indexOf(String)]]></name>
+    <configKey><![CDATA[IIO_INEFFICIENT_INDEX_OF]]></configKey>
+  </rule>
+
+  <rule key="IIO_INEFFICIENT_LAST_INDEX_OF">
+    <priority>MAJOR</priority>
+    <name><![CDATA[Inefficient use of String.lastIndexOf(String)]]></name>
+    <configKey><![CDATA[IIO_INEFFICIENT_LAST_INDEX_OF]]></configKey>
+  </rule>
+
+  <rule key="CNT_ROUGH_CONSTANT_VALUE">
+    <priority>MAJOR</priority>
+    <name><![CDATA[Rough value of known constant found]]></name>
+    <configKey><![CDATA[CNT_ROUGH_CONSTANT_VALUE]]></configKey>
+  </rule>
+
 </rules>

--- a/src/test/java/org/sonar/plugins/findbugs/FindbugsRuleRepositoryTest.java
+++ b/src/test/java/org/sonar/plugins/findbugs/FindbugsRuleRepositoryTest.java
@@ -42,7 +42,7 @@ public class FindbugsRuleRepositoryTest {
   public void testLoadRepositoryFromXml() {
     List<Rule> rules = repository.createRules();
 
-    assertThat(rules.size()).isEqualTo(419);
+    assertThat(rules.size()).isEqualTo(423);
     for (Rule rule : rules) {
       assertThat(rule.getKey()).isNotNull();
       assertThat(rule.getConfigKey()).isNotNull();


### PR DESCRIPTION
This forces to use Java 7 for execution of tests.

There is 4 new rules:
- NP_OPTIONAL_RETURN_NULL
- IIO_INEFFICIENT_INDEX_OF
- IIO_INEFFICIENT_LAST_INDEX_OF
- CNT_ROUGH_CONSTANT_VALUE
