### PR TITLE
Minor changes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ deploy:
   # deploy SNAPSHOT artifact onto Sonatype Nexus
   - provider: script
     skip_cleanup: true
-    script: mvn deploy -B -P deploy -s .travis/settings.xml
+    script: mvn deploy -B -P -Dgpg.skip deploy -s .travis/settings.xml
     on:
       branch: master
   # deploy STABLE artifact onto Sonatype Nexus

--- a/README.md
+++ b/README.md
@@ -46,4 +46,4 @@ Findbugs Plugin version|Embedded SpotBugs/Findbugs version|Embedded Findsecbugs 
 3.4                    | 3.0.1                            | 1.4.6                      | 6.6.1                     | 1.8
 3.5                    | 3.1.0 RC1 (SpotBugs)             | 1.6.0                      | 7.0.0                     | 1.8
 3.6                    | 3.1.0 RC4 (SpotBugs)             | 1.6.0                      | 7.0.0                     | 1.8
-3.7-SNAPSHOT           | 3.1.0 (SpotBugs)                 | 1.7.1                      | 7.0.5sb                   | 1.8
+3.7-SNAPSHOT           | 3.1.1 (SpotBugs)                 | 1.7.1                      | 7.0.5sb                   | 1.8

--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
   </scm>
 
   <properties>
-    <spotbugs.version>3.1.0</spotbugs.version>
+    <spotbugs.version>3.1.1</spotbugs.version>
     <jdk.min.version>1.8</jdk.min.version>
 
     <sonar.version>5.6.6</sonar.version>


### PR DESCRIPTION
1. Use the latest SpotBugs
2. Stop signing jar files in post-merge build, to avoid STABLE deployment