### PR TITLE
#148 Excluded Java Server Pages (JSPs) from Java source files to fix failure when analyzing module with non-compiled JSPs

### DIFF
--- a/src/main/java/org/sonar/plugins/findbugs/FindbugsConfiguration.java
+++ b/src/main/java/org/sonar/plugins/findbugs/FindbugsConfiguration.java
@@ -164,7 +164,8 @@ public class FindbugsConfiguration {
                     //package-info.java will not generate any class files.
                     //See: https://github.com/SonarQubeCommunity/sonar-findbugs/issues/36
                     pred.not(pred.matchesPathPattern("**/package-info.java")),
-                    pred.not(pred.matchesPathPattern("**/module-info.java"))
+                    pred.not(pred.matchesPathPattern("**/module-info.java")),
+                    pred.not(pred.matchesPathPattern("**/*.jsp"))
             )
     );
   }


### PR DESCRIPTION
Hello,
I propose a quick fix of the issue:
https://github.com/spotbugs/sonar-findbugs/issues/148