### PR TITLE
Fixed warning about platform dependent build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,6 +55,7 @@
     <fbcontrib.version>7.2.1.sb</fbcontrib.version>
     <findsecbugs.version>1.7.1</findsecbugs.version>
 
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
   </properties>
 


### PR DESCRIPTION
I added **project.build.sourceEncoding** property to the pom.xml file to fix maven warning:
[WARNING] File encoding has not been set, using platform encoding Cp1250, i.e. build is platform dependent!

I believe it's a good practise to specify the encoding in POM files.