### PR TITLE
replace old badge with new one

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # SonarQube Spotbugs Plugin
 [![Build Status](https://travis-ci.org/spotbugs/sonar-findbugs.svg?branch=master)](https://travis-ci.org/spotbugs/sonar-findbugs)
 ![FindBugs Rules](https://img.shields.io/badge/SpotBugs_rules-818-brightgreen.svg?maxAge=2592000)
-[![Coverage Status](https://sonarcloud.io/api/badges/measure?key=com.github.spotbugs:sonar-findbugs-plugin&metric=coverage)](https://sonarcloud.io/component_measures?id=com.github.spotbugs:sonar-findbugs-plugin&metric=coverage)
+[![Coverage Status](https://sonarcloud.io/api/project_badges/measure?project=com.github.spotbugs%3Asonar-findbugs-plugin&metric=coverage)](https://sonarcloud.io/component_measures?id=com.github.spotbugs:sonar-findbugs-plugin&metric=coverage)
 
 ## Description / Features
 


### PR DESCRIPTION
refer https://about.sonarcloud.io/news/2018/02/05/new-project-badges.html