### PR TITLE
Replace BatchExtension for SQ 7.3 compatibility #204 

### DIFF
--- a/src/main/java/org/sonar/plugins/findbugs/FindbugsConfiguration.java
+++ b/src/main/java/org/sonar/plugins/findbugs/FindbugsConfiguration.java
@@ -33,7 +33,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.sonar.api.CoreProperties;
 import org.sonar.api.PropertyType;
-import org.sonar.api.batch.BatchSide;
+import org.sonar.api.batch.ScannerSide;
 import org.sonar.api.batch.fs.FilePredicates;
 import org.sonar.api.batch.fs.FileSystem;
 import org.sonar.api.batch.fs.InputFile.Type;
@@ -50,7 +50,7 @@ import java.io.InputStream;
 import java.io.StringWriter;
 import java.util.*;
 
-@BatchSide
+@ScannerSide
 public class FindbugsConfiguration {
 
   private static final Logger LOG = LoggerFactory.getLogger(FindbugsConfiguration.class);

--- a/src/main/java/org/sonar/plugins/findbugs/FindbugsExecutor.java
+++ b/src/main/java/org/sonar/plugins/findbugs/FindbugsExecutor.java
@@ -39,7 +39,7 @@ import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.sonar.api.batch.BatchSide;
+import org.sonar.api.batch.ScannerSide;
 import org.sonar.api.batch.fs.FileSystem;
 import org.sonar.api.config.Configuration;
 
@@ -57,7 +57,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
-@BatchSide
+@ScannerSide
 public class FindbugsExecutor {
 
   private static final String FINDBUGS_CORE_PLUGIN_ID = "edu.umd.cs.findbugs.plugins.core";

--- a/src/main/java/org/sonar/plugins/findbugs/resource/ByteCodeResourceLocator.java
+++ b/src/main/java/org/sonar/plugins/findbugs/resource/ByteCodeResourceLocator.java
@@ -22,7 +22,7 @@ package org.sonar.plugins.findbugs.resource;
 import org.apache.commons.io.IOUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.sonar.api.BatchExtension;
+import org.sonar.api.ExtensionPoint;
 import org.sonar.api.batch.fs.FileSystem;
 import org.sonar.api.batch.fs.InputFile;
 import org.sonar.plugins.java.api.JavaResourceLocator;
@@ -40,7 +40,8 @@ import java.util.List;
 /**
  * Utility method related to mapped class name to various resources and extracting addition information.
  */
-public class ByteCodeResourceLocator implements BatchExtension {
+@ExtensionPoint
+public class ByteCodeResourceLocator {
 
 
     private static final Logger LOG = LoggerFactory.getLogger(ByteCodeResourceLocator.class);


### PR DESCRIPTION
BatchExtension has been removed in SonarQube 7.3 ( https://jira.sonarsource.com/browse/SONAR-10138 ). BatchExtension replaced for the SonarQube 7.3 compatibility #204 