### PR TITLE
SonarQube 7.3 (latest) compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,10 @@ jdk:
 env:
   # latest LTS
   - SONAR_VERSION=6.7.1 SONAR_JAVA_VERSION=5.1.0.13090
-  # latest
+  # 7.0
   - SONAR_VERSION=7.0 SONAR_JAVA_VERSION=5.1.1.13214
+  # 7.3
+  - SONAR_VERSION=7.3 SONAR_JAVA_VERSION=5.6.1.15064
 install:
   # decrypt settings.xml, pubring.gpg and secring.gpg
   - if [ -n "$encrypted_b6710039761a_key" ]; then openssl aes-256-cbc -K $encrypted_b6710039761a_key -iv $encrypted_b6710039761a_iv -in .travis/secrets.tar.enc -out .travis/secrets.tar -d; fi

--- a/pom.xml
+++ b/pom.xml
@@ -205,13 +205,6 @@
       <version>1.6</version>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>org.sonarsource.sonarqube</groupId>
-      <artifactId>sonar-plugin-api</artifactId>
-      <version>${sonar.version}</version>
-      <type>test-jar</type>
-      <scope>test</scope>
-    </dependency>
 
 
     <!-- Utilities use by the lexer -->

--- a/src/main/java/org/sonar/plugins/findbugs/resource/ByteCodeResourceLocator.java
+++ b/src/main/java/org/sonar/plugins/findbugs/resource/ByteCodeResourceLocator.java
@@ -23,6 +23,7 @@ import org.apache.commons.io.IOUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.sonar.api.ExtensionPoint;
+import org.sonar.api.batch.ScannerSide;
 import org.sonar.api.batch.fs.FileSystem;
 import org.sonar.api.batch.fs.InputFile;
 import org.sonar.plugins.java.api.JavaResourceLocator;
@@ -40,7 +41,7 @@ import java.util.List;
 /**
  * Utility method related to mapped class name to various resources and extracting addition information.
  */
-@ExtensionPoint
+@ScannerSide
 public class ByteCodeResourceLocator {
 
 


### PR DESCRIPTION
Change ExtensionPoint annotation to ScannerSide (class ByteCodeResourceLocator)

This seems to be the last element missing to complete the migration to SonarQube 7.3.

I have added the compatibility testing for 7.3 in the travis.yml. https://github.com/spotbugs/sonar-findbugs/pull/209/commits/6e6e48babbff90b6c6714ae82c57401a1be4056f