### PR TITLE
Update SpotBugs to 3.1.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,4 +46,4 @@ Findbugs Plugin version|Embedded SpotBugs/Findbugs version|Embedded Findsecbugs 
 3.6                    | 3.1.0 RC4 (SpotBugs)             | 1.6.0                      | 7.0.0                     | 1.8|5.6.7|4.15.0.12310
 3.7                    | 3.1.2 (SpotBugs)                 | 1.7.1                      | 7.2.1sb                   | 1.8|6.7.1|5.1.0.13090
 3.8                    | 3.1.6 (SpotBugs)                 | 1.8.0                      | 7.4.3sb                   | 1.8|6.7.1|5.1.0.13090
-3.9-SNAPSHOT           | 3.1.6 (SpotBugs)                 | 1.8.0                      | 7.4.3sb                   | 1.8|6.7.1|5.1.0.13090
+3.9-SNAPSHOT           | 3.1.7 (SpotBugs)                 | 1.8.0                      | 7.4.3sb                   | 1.8|6.7.1|5.1.0.13090

--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
   </scm>
 
   <properties>
-    <spotbugs.version>3.1.6</spotbugs.version>
+    <spotbugs.version>3.1.7</spotbugs.version>
     <jdk.min.version>1.8</jdk.min.version>
 
     <sonar.version>6.7.1</sonar.version>


### PR DESCRIPTION
Java 11 was released on September 25th and is the new LTS version.

At this point sonar-findbugs is not able to analyse projects built with Java 11, but fortunately SpotBugs has added proper support in release 3.1.7 (see [#750](https://github.com/spotbugs/spotbugs/pull/750)). This pull request simply bumps up the dependency version used by sonar-findbugs.

Note that I have built an artifact based on this fork and have uploaded it to our SonarQube server, and I can confirm that our Java 11 projects are now happily being analysed. 👍 