### PR TITLE
Update sonar-java to support SonarQube LTS 6.7 correctly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,11 +5,14 @@ jdk:
   - oraclejdk8
 env:
   # latest LTS
-  - SONAR_VERSION=6.7.1 SONAR_JAVA_VERSION=5.1.0.13090
-  # 7.0
-  - SONAR_VERSION=7.0 SONAR_JAVA_VERSION=5.1.1.13214
-  # 7.3
-  - SONAR_VERSION=7.3 SONAR_JAVA_VERSION=5.6.1.15064
+  - SONAR_VERSION=6.7.5 SONAR_JAVA_VERSION=5.2.0.13398
+  # latest stable releases
+  - SONAR_VERSION=7.3 SONAR_JAVA_VERSION=5.8.0.15699
+  # latest releases that removes some API
+  - SONAR_VERSION=7.4 SONAR_JAVA_VERSION=5.8.0.15699
+matrix:
+  allow_failures:
+  - env: SONAR_VERSION=7.4 SONAR_JAVA_VERSION=5.8.0.15699
 install:
   # decrypt settings.xml, pubring.gpg and secring.gpg
   - if [ -n "$encrypted_b6710039761a_key" ]; then openssl aes-256-cbc -K $encrypted_b6710039761a_key -iv $encrypted_b6710039761a_iv -in .travis/secrets.tar.enc -out .travis/secrets.tar -d; fi

--- a/README.md
+++ b/README.md
@@ -46,4 +46,4 @@ Findbugs Plugin version|Embedded SpotBugs/Findbugs version|Embedded Findsecbugs 
 3.6                    | 3.1.0 RC4 (SpotBugs)             | 1.6.0                      | 7.0.0                     | 1.8|5.6.7|4.15.0.12310
 3.7                    | 3.1.2 (SpotBugs)                 | 1.7.1                      | 7.2.1sb                   | 1.8|6.7.1|5.1.0.13090
 3.8                    | 3.1.6 (SpotBugs)                 | 1.8.0                      | 7.4.3sb                   | 1.8|6.7.1|5.1.0.13090
-3.9-SNAPSHOT           | 3.1.8 (SpotBugs)                 | 1.8.0                      | 7.4.3sb                   | 1.8|6.7.1|5.1.0.13090
+3.9-SNAPSHOT           | 3.1.8 (SpotBugs)                 | 1.8.0                      | 7.4.3sb                   | 1.8|6.7.1|5.2.0.13398

--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
     <jdk.min.version>1.8</jdk.min.version>
 
     <sonar.version>6.7.1</sonar.version>
-    <sonar-java.version>5.1.0.13090</sonar-java.version>
+    <sonar-java.version>5.2.0.13398</sonar-java.version>
     <fbcontrib.version>7.4.3.sb</fbcontrib.version>
     <findsecbugs.version>1.8.0</findsecbugs.version>
 


### PR DESCRIPTION
sonar-java has released 5.2.0 that supports SonarQube 6.7. See:

- SonarSource/sslr-squid-bridge@d481fef
- SonarSource/sonar-java@0ca6061

In other words, sonar-java 5.1 does not support latest LTS 6.7.x. To support SonarQube 6.7.x, sonar-findbugs should depend on sonar-java 5.2.0 or later.

Also, SonarQube released 6.7.5 and 7.4, so use them in CI build. I'll try to fix 7.4 compatibility problem by another PR.