### PR TITLE
Package sonar-channel that is removed from SonarQube plugin API 7.4

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+*
+!target/sonar-findbugs-plugin.jar
+!src/smoke-test

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,13 +8,8 @@ services:
 env:
   # latest LTS
   - SONAR_VERSION=6.7.5 SONAR_JAVA_VERSION=5.2.0.13398
-  # latest stable releases
-  - SONAR_VERSION=7.3 SONAR_JAVA_VERSION=5.8.0.15699
-  # latest releases that removes some API
+  # latest releases
   - SONAR_VERSION=7.4 SONAR_JAVA_VERSION=5.8.0.15699
-matrix:
-  allow_failures:
-  - env: SONAR_VERSION=7.4 SONAR_JAVA_VERSION=5.8.0.15699
 install:
   # decrypt settings.xml, pubring.gpg and secring.gpg
   - if [ -n "$encrypted_b6710039761a_key" ]; then openssl aes-256-cbc -K $encrypted_b6710039761a_key -iv $encrypted_b6710039761a_iv -in .travis/secrets.tar.enc -out .travis/secrets.tar -d; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,10 @@
 language: java
-sudo: false
+sudo: required
 dist: trusty
 jdk:
   - oraclejdk8
+services:
+  - docker
 env:
   # latest LTS
   - SONAR_VERSION=6.7.5 SONAR_JAVA_VERSION=5.2.0.13398
@@ -21,6 +23,11 @@ script:
   - mvn verify -B -e -V -Dsonar.version=$SONAR_VERSION -Dsonar-java.version=$SONAR_JAVA_VERSION
 jobs:
   include:
+    - stage: smoke-test
+      script:
+        - 'mvn package && docker-compose -f src/smoke-test/docker-compose.yml --project-directory . run --rm test-lts'
+    - script:
+        - 'mvn package && docker-compose -f src/smoke-test/docker-compose.yml --project-directory . run --rm test-latest'
     - stage: analysis
       if: ( type = pull_request and head_repo =~ ^spotbugs/ ) or ( type != pull_request and repo =~ ^spotbugs/ )
       script:

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>com.github.spotbugs</groupId>
   <artifactId>sonar-findbugs-plugin</artifactId>
-  <version>3.9.1</version>
+  <version>3.10.0-SNAPSHOT</version>
   <packaging>sonar-plugin</packaging>
 
   <name>SonarQube SpotBugs Plugin</name>

--- a/pom.xml
+++ b/pom.xml
@@ -213,7 +213,11 @@
       <artifactId>sslr-core</artifactId>
       <version>1.22</version>
     </dependency>
-
+    <dependency>
+      <groupId>org.codehaus.sonar</groupId>
+      <artifactId>sonar-channel</artifactId>
+      <version>4.2</version>
+    </dependency>
   </dependencies>
 
   <build>
@@ -303,6 +307,38 @@
                   </files>
                 </requireFilesSize>
               </rules>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
+        <version>3.2.1</version>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+            <configuration>
+              <artifactSet>
+                <includes>
+                  <include>commons-io:commons-io</include>
+                  <include>org.codehaus.sonar:sonar-channel</include>
+                </includes>
+              </artifactSet>
+              <relocations>
+                <relocation>
+                  <pattern>org.apache.commons.io</pattern>
+                  <shadedPattern>shaded.io</shadedPattern>
+                </relocation>
+                  <relocation>
+                    <pattern>org.sonar.channel</pattern>
+                    <shadedPattern>shaded.channel</shadedPattern>
+                  </relocation>
+              </relocations>
+              <createDependencyReducedPom>false</createDependencyReducedPom>
             </configuration>
           </execution>
         </executions>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>com.github.spotbugs</groupId>
   <artifactId>sonar-findbugs-plugin</artifactId>
-  <version>3.10.0-SNAPSHOT</version>
+  <version>3.9.1-SNAPSHOT</version>
   <packaging>sonar-plugin</packaging>
 
   <name>SonarQube SpotBugs Plugin</name>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>com.github.spotbugs</groupId>
   <artifactId>sonar-findbugs-plugin</artifactId>
-  <version>3.9.1-SNAPSHOT</version>
+  <version>3.9.1</version>
   <packaging>sonar-plugin</packaging>
 
   <name>SonarQube SpotBugs Plugin</name>

--- a/src/smoke-test/docker-compose.yml
+++ b/src/smoke-test/docker-compose.yml
@@ -1,0 +1,46 @@
+version: '3'
+services:
+  sonarqube-lts:
+    build:
+      context: .
+      dockerfile: src/smoke-test/sonarqube-lts
+    expose:
+      - 9000
+    networks:
+      lts:
+        aliases:
+          - sonarqube
+  sonarqube-latest:
+    build:
+      context: .
+      dockerfile: src/smoke-test/sonarqube-latest
+    expose:
+      - 9000
+    networks:
+      latest:
+        aliases:
+          - sonarqube
+  test-lts:
+    build:
+      context: .
+      dockerfile: src/smoke-test/sonarqube-client
+    volumes:
+      - '~/.m2:/root/.m2'
+    depends_on:
+      - sonarqube-lts
+    networks:
+      lts:
+  test-latest:
+    build:
+      context: .
+      dockerfile: src/smoke-test/sonarqube-client
+    volumes:
+      - '~/.m2:/root/.m2'
+    depends_on:
+      - sonarqube-latest
+    networks:
+      latest:
+
+networks:
+  lts:
+  latest:

--- a/src/smoke-test/run.sh
+++ b/src/smoke-test/run.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+# Copied from https://github.com/SonarSource/docker-sonarqube/tree/master/7.1 under LGPL
+
+set -e
+
+if [ "${1:0:1}" != '-' ]; then
+  exec "$@"
+fi
+
+chown -R sonarqube:sonarqube $SONARQUBE_HOME
+exec gosu sonarqube \
+  java -jar lib/sonar-application-$SONAR_VERSION.jar \
+  -Dsonar.log.console=true \
+  -Dsonar.jdbc.username="$SONARQUBE_JDBC_USERNAME" \
+  -Dsonar.jdbc.password="$SONARQUBE_JDBC_PASSWORD" \
+  -Dsonar.jdbc.url="$SONARQUBE_JDBC_URL" \
+  -Dsonar.web.javaAdditionalOpts="$SONARQUBE_WEB_JVM_OPTS -Djava.security.egd=file:/dev/./urandom" \
+  "$@"

--- a/src/smoke-test/smoke-test.sh
+++ b/src/smoke-test/smoke-test.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+
+set -eu
+
+# 1st param... The git URL to clone
+# 2nd param... The tag name to check out
+function download_target_project() {
+  DIR_NAME=$(mktemp -d)
+  cd /$DIR_NAME
+  git clone "$1" target_repo
+  cd target_repo
+  git checkout "$2"
+}
+
+function run_smoke_test() {
+  echo -n waiting SonarQube
+  until $(curl --output /dev/null -s --fail http://sonarqube:9000); do
+    echo -n '.'
+    sleep 5
+  done
+  echo SonarQube has been launched.
+
+  count=0
+  until mvn compile org.eclipse.jetty:jetty-jspc-maven-plugin:jspc org.sonarsource.scanner.maven:sonar-maven-plugin:3.5.0.1254:sonar -B -Dmaven.test.skip -Dsonar.profile="FindBugs + FB-Contrib" -Dsonar.host.url=http://sonarqube:9000 -Dsonar.login=admin -Dsonar.password=admin; do
+    count=$[ $count + 1 ]
+    if [ $count -ge 5 ]; then
+      echo Sonar fails to scan 5 times!
+      exit 1
+    fi
+    echo SonarQube is not ready to scan project, wait 5 sec
+    sleep 5
+  done
+}
+
+# Use the project that uses Maven and contains .jsp file
+download_target_project 'https://github.com/spring-projects/spring-petclinic.git' 'e9f5f7b54108e35e660a9c9311a682ddce0633bc'
+run_smoke_test

--- a/src/smoke-test/sonarqube-client
+++ b/src/smoke-test/sonarqube-client
@@ -1,0 +1,10 @@
+FROM maven:3.6.0-jdk-8
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+  bash \
+  git \
+  nodejs \
+  && rm -rf /var/lib/apt/lists/*
+
+COPY src/smoke-test/smoke-test.sh /tmp/smoke-test.sh
+ENTRYPOINT /tmp/smoke-test.sh

--- a/src/smoke-test/sonarqube-latest
+++ b/src/smoke-test/sonarqube-latest
@@ -1,0 +1,55 @@
+# Copied from https://github.com/SonarSource/docker-sonarqube/tree/master/7.1 under LGPL
+FROM openjdk:8
+
+ENV SONAR_VERSION=7.4 \
+    SONARQUBE_HOME=/opt/sonarqube \
+    # Database configuration
+    # Defaults to using H2
+    SONARQUBE_JDBC_USERNAME=sonar \
+    SONARQUBE_JDBC_PASSWORD=sonar \
+    SONARQUBE_JDBC_URL=
+
+# Http port
+EXPOSE 9000
+
+RUN groupadd -r sonarqube && useradd -r -g sonarqube sonarqube
+
+# grab gosu for easy step-down from root
+RUN set -x \
+    && wget -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/1.10/gosu-$(dpkg --print-architecture)" \
+    && wget -O /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/1.10/gosu-$(dpkg --print-architecture).asc" \
+    && export GNUPGHOME="$(mktemp -d)" \
+    && (gpg --keyserver ha.pool.sks-keyservers.net --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 \
+        || gpg --keyserver ipv4.pool.sks-keyservers.net --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4) \
+    && gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu \
+    && rm -rf "$GNUPGHOME" /usr/local/bin/gosu.asc \
+    && chmod +x /usr/local/bin/gosu \
+    && gosu nobody true
+
+RUN set -x \
+
+    # pub   2048R/D26468DE 2015-05-25
+    #       Key fingerprint = F118 2E81 C792 9289 21DB  CAB4 CFCA 4A29 D264 68DE
+    # uid                  sonarsource_deployer (Sonarsource Deployer) <infra@sonarsource.com>
+    # sub   2048R/06855C1D 2015-05-25
+    && (gpg --keyserver ha.pool.sks-keyservers.net --recv-keys F1182E81C792928921DBCAB4CFCA4A29D26468DE \
+	    || gpg --keyserver ipv4.pool.sks-keyservers.net --recv-keys F1182E81C792928921DBCAB4CFCA4A29D26468DE) \
+
+    && cd /opt \
+    && curl -o sonarqube.zip -fSL https://binaries.sonarsource.com/Distribution/sonarqube/sonarqube-$SONAR_VERSION.zip \
+    && curl -o sonarqube.zip.asc -fSL https://binaries.sonarsource.com/Distribution/sonarqube/sonarqube-$SONAR_VERSION.zip.asc \
+    && gpg --batch --verify sonarqube.zip.asc sonarqube.zip \
+    && unzip sonarqube.zip \
+    && mv sonarqube-$SONAR_VERSION sonarqube \
+    && chown -R sonarqube:sonarqube sonarqube \
+    && rm sonarqube.zip* \
+    && rm -rf $SONARQUBE_HOME/bin/*
+
+VOLUME "$SONARQUBE_HOME/data"
+
+WORKDIR $SONARQUBE_HOME
+COPY src/smoke-test/run.sh $SONARQUBE_HOME/bin/
+ENTRYPOINT ["./bin/run.sh"]
+
+# modified for smoke-test
+COPY target/sonar-findbugs-plugin.jar $SONARQUBE_HOME/extensions/plugins/

--- a/src/smoke-test/sonarqube-latest
+++ b/src/smoke-test/sonarqube-latest
@@ -19,8 +19,8 @@ RUN set -x \
     && wget -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/1.10/gosu-$(dpkg --print-architecture)" \
     && wget -O /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/1.10/gosu-$(dpkg --print-architecture).asc" \
     && export GNUPGHOME="$(mktemp -d)" \
-    && (gpg --keyserver ha.pool.sks-keyservers.net --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 \
-        || gpg --keyserver ipv4.pool.sks-keyservers.net --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4) \
+    && (gpg --batch --keyserver ha.pool.sks-keyservers.net --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 \
+        || gpg --batch --keyserver ipv4.pool.sks-keyservers.net --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4) \
     && gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu \
     && rm -rf "$GNUPGHOME" /usr/local/bin/gosu.asc \
     && chmod +x /usr/local/bin/gosu \
@@ -32,8 +32,8 @@ RUN set -x \
     #       Key fingerprint = F118 2E81 C792 9289 21DB  CAB4 CFCA 4A29 D264 68DE
     # uid                  sonarsource_deployer (Sonarsource Deployer) <infra@sonarsource.com>
     # sub   2048R/06855C1D 2015-05-25
-    && (gpg --keyserver ha.pool.sks-keyservers.net --recv-keys F1182E81C792928921DBCAB4CFCA4A29D26468DE \
-	    || gpg --keyserver ipv4.pool.sks-keyservers.net --recv-keys F1182E81C792928921DBCAB4CFCA4A29D26468DE) \
+    && (gpg --batch --keyserver ha.pool.sks-keyservers.net --recv-keys F1182E81C792928921DBCAB4CFCA4A29D26468DE \
+	    || gpg --batch --keyserver ipv4.pool.sks-keyservers.net --recv-keys F1182E81C792928921DBCAB4CFCA4A29D26468DE) \
 
     && cd /opt \
     && curl -o sonarqube.zip -fSL https://binaries.sonarsource.com/Distribution/sonarqube/sonarqube-$SONAR_VERSION.zip \

--- a/src/smoke-test/sonarqube-lts
+++ b/src/smoke-test/sonarqube-lts
@@ -1,0 +1,5 @@
+FROM sonarqube:6.7.5
+ENV SONAR_JAVA_VERSION=5.2.0.13398
+
+RUN wget -P $SONARQUBE_HOME/extensions/plugins/ --no-verbose http://central.maven.org/maven2/org/sonarsource/java/sonar-java-plugin/$SONAR_JAVA_VERSION/sonar-java-plugin-$SONAR_JAVA_VERSION.jar
+COPY target/sonar-findbugs-plugin.jar $SONARQUBE_HOME/extensions/plugins/


### PR DESCRIPTION
As described in #225, `sonar-channel` and `commons-io` has been removed from SonarQube plugin API 7.4. This is why [the build with SonarQube plugin API 7.4 is failing](https://travis-ci.org/spotbugs/sonar-findbugs/jobs/452346817), and sonar-findbugs 3.9 lacks compatibility with SonarQube 7.4.

In this PR, I reproduce reported issue #226 by smoke test, and fix it by packaging `sonar-channel` and `commons-io` into sonar-findbugs. We need to use `maven-shade-plugin` because `sonar-packaging-maven-plugin` does not package these two libraries. Here is message:

> [WARNING] commons-io:commons-io:jar:2.6:compile is provided by SonarQube plugin API and will not be packaged in your plugin
> [WARNING] org.codehaus.sonar:sonar-channel:jar:4.2:compile is provided by SonarQube plugin API and will not be packaged in your plugin

So to support both SonarQube 6.7 and 7.4, we need to shade these libraries. To avoid classloader related issue, I also changed their package path.

This PR closes #225 and #226.