### PR TITLE
Make smoke-test stable even in master branch

### DIFF
--- a/src/smoke-test/docker-compose.yml
+++ b/src/smoke-test/docker-compose.yml
@@ -24,8 +24,6 @@ services:
     build:
       context: .
       dockerfile: src/smoke-test/sonarqube-client
-    volumes:
-      - '~/.m2:/root/.m2'
     depends_on:
       - sonarqube-lts
     networks:
@@ -34,8 +32,6 @@ services:
     build:
       context: .
       dockerfile: src/smoke-test/sonarqube-client
-    volumes:
-      - '~/.m2:/root/.m2'
     depends_on:
       - sonarqube-latest
     networks:


### PR DESCRIPTION
On Travis CI, it is possible that docker image fails to make directory
under .m2 file due to permission problem. To avoid this issue, stop
sharing local repository. It may make build elapsed time londer.

I'm not sure why this failure didn't occur in PR and topic branch, it could be non-documented behabiour of Travis.

refs #231