### PR TITLE
Improve Build Scripts and Configurations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,14 +19,24 @@ script:
 jobs:
   include:
     - stage: smoke-test
-      script:
-        - 'mvn package && docker-compose -f src/smoke-test/docker-compose.yml --project-directory . run --rm test-lts'
-    - script:
-        - 'mvn package && docker-compose -f src/smoke-test/docker-compose.yml --project-directory . run --rm test-latest'
+      name: 'on SonarQube LTS (6.7.x)'
+      script: 'mvn package && docker-compose -f src/smoke-test/docker-compose.yml --project-directory . run --rm test-lts'
+    - name: 'on SonarQube latest (7.x)'
+      script: 'mvn package && docker-compose -f src/smoke-test/docker-compose.yml --project-directory . run --rm test-latest'
     - stage: analysis
-      if: ( type = pull_request and head_repo =~ ^spotbugs/ ) or ( type != pull_request and repo =~ ^spotbugs/ )
       script:
         - mvn org.jacoco:jacoco-maven-plugin:prepare-agent verify sonar:sonar -B -e -V -Dsonar.version=$SONAR_VERSION -Dsonar-java.version=$SONAR_JAVA_VERSION
+    - stage: deploy
+      script: mvn deploy -B -P deploy -s .travis/settings.xml
+      on:
+        tags: true
+stages:
+  - test
+  - smoke-test
+  - name: analysis
+    if: ( type = pull_request and head_repo =~ ^spotbugs/ ) or ( type != pull_request and repo =~ ^spotbugs/ )
+  - name: deploy
+    if: ( branch = master ) or ( tag IS present )
 notifications:
   email: false
 addons:
@@ -36,18 +46,3 @@ addons:
       secure: "TO179WgRUyyT2Yg92FpC1r746GaHDMZ7+rMiBqnXztoj5VWTn8U0+M9edyxQ+cKZtCznC4JoimdjBhne52vauWFuQsoczrxtnN7l4w+yemC799Mm5jEuPKoId1CQZkVc5g4hmmeV4Qg6H5K1or1gnl+MGGZ9tbUYOu2v+G2SyAA="
     github_token:
       secure: "F37JqWPpdlOl4oHvTAap9uw+MEqmIz60HiVKYmSpQHDZRb13VJ/pVO11GVhoUfiswOERIEe6Ot/diH/ZK7qhaJQtPJVdSHLyN5t9KSdLtP9wYHWINVR79q8nM7I0rOZ94XDbBsHEsFgC/IWAYizVavQpMw5AGt31qjTzac19BVQ="
-deploy:
-  # deploy SNAPSHOT artifact onto Sonatype Nexus
-  - provider: script
-    skip_cleanup: true
-    script: mvn deploy -B -P deploy -Dgpg.skip -s .travis/settings.xml
-    on:
-      branch: master
-      condition: "$SONAR_VERSION = '6.7'*"
-  # deploy STABLE artifact onto Sonatype Nexus
-  - provider: script
-    skip_cleanup: true
-    script: mvn deploy -B -P deploy -s .travis/settings.xml
-    on:
-      tags: true
-      condition: "$SONAR_VERSION = '6.7'*"

--- a/README.md
+++ b/README.md
@@ -47,4 +47,4 @@ Findbugs Plugin version|Embedded SpotBugs/Findbugs version|Embedded Findsecbugs 
 3.7                    | 3.1.2 (SpotBugs)                 | 1.7.1                      | 7.2.1sb                   | 1.8|6.7.1|5.1.0.13090
 3.8                    | 3.1.6 (SpotBugs)                 | 1.8.0                      | 7.4.3sb                   | 1.8|6.7.1|5.1.0.13090
 3.9                    | 3.1.8 (SpotBugs)                 | 1.8.0                      | 7.4.3sb                   | 1.8|6.7.1|5.2.0.13398
-3.10-SNAPSHOT          | 3.1.8 (SpotBugs)                 | 1.8.0                      | 7.4.3sb                   | 1.8|6.7.1|5.2.0.13398
+3.10-SNAPSHOT          | 3.1.9 (SpotBugs)                 | 1.8.0                      | 7.4.3sb                   | 1.8|6.7.1|5.2.0.13398

--- a/generate_profiles/BuildXmlFiles.groovy
+++ b/generate_profiles/BuildXmlFiles.groovy
@@ -3,13 +3,13 @@ import FsbClassifier;
 import static FsbClassifier.*;
 @Grapes([
 
-    @Grab(group='com.github.spotbugs', module='spotbugs', version='3.1.8'),
+    @Grab(group='com.github.spotbugs', module='spotbugs', version='3.1.9'),
     @Grab(group='com.mebigfatguy.fb-contrib', module='fb-contrib', version='7.4.3.sb'),
     @Grab(group='com.h3xstream.findsecbugs' , module='findsecbugs-plugin', version='1.8.0')]
 )
 
 
-FB = new Plugin(groupId: 'com.github.spotbugs', artifactId: 'spotbugs', version: '3.1.8')
+FB = new Plugin(groupId: 'com.github.spotbugs', artifactId: 'spotbugs', version: '3.1.9')
 CONTRIB = new Plugin(groupId: 'com.mebigfatguy.fb-contrib', artifactId: 'fb-contrib', version: '7.4.3.sb')
 FSB = new Plugin(groupId: 'com.h3xstream.findsecbugs', artifactId: 'findsecbugs-plugin', version: '1.8.0')
 

--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
   </scm>
 
   <properties>
-    <spotbugs.version>3.1.8</spotbugs.version>
+    <spotbugs.version>3.1.9</spotbugs.version>
     <jdk.min.version>1.8</jdk.min.version>
 
     <sonar.version>6.7.1</sonar.version>


### PR DESCRIPTION
1. SpotBugs 3.1.9 has been released, so we can use it for [better Java 11 support and other improvements](https://github.com/spotbugs/spotbugs/blob/3.1.9/CHANGELOG.md#319---2018-11-20).
2. Move deploy phase to the end of build pipeline, to ensure that packages are deployed only when it passes smoke-test and SonarCloud analysis.