### PR TITLE
Bump up SonarQube LTS to 6.7.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ services:
   - docker
 env:
   # latest LTS
-  - SONAR_VERSION=6.7.5 SONAR_JAVA_VERSION=5.2.0.13398
+  - SONAR_VERSION=6.7.6 SONAR_JAVA_VERSION=5.2.0.13398
   # latest releases
   - SONAR_VERSION=7.4 SONAR_JAVA_VERSION=5.8.0.15699
 install:

--- a/src/smoke-test/sonarqube-lts
+++ b/src/smoke-test/sonarqube-lts
@@ -1,4 +1,4 @@
-FROM sonarqube:6.7.5
+FROM sonarqube:6.7.6-community
 ENV SONAR_JAVA_VERSION=5.2.0.13398
 
 RUN wget -P $SONARQUBE_HOME/extensions/plugins/ --no-verbose http://central.maven.org/maven2/org/sonarsource/java/sonar-java-plugin/$SONAR_JAVA_VERSION/sonar-java-plugin-$SONAR_JAVA_VERSION.jar


### PR DESCRIPTION
Bump up the SonarQube version that is used in test.

This change doesn't affect the released artifact; the `MANIFEST.MF` file in jar file keeps using `Sonar-Version: 6.7.1`.