### PR TITLE
Giving support to Scala rules

### DIFF
--- a/generate_profiles/BuildXmlFiles.groovy
+++ b/generate_profiles/BuildXmlFiles.groovy
@@ -195,12 +195,14 @@ def writeRules(String rulesSetName,List<Plugin> plugins,List<String> includedBug
 }
 
 def securityJspRules = majorJspBugs + criticalJspBugs
+def securityScalaRules = criticalScalaBugs
 
 //FindBugs
-writeRules("findbugs", [FB], [], securityJspRules)
+writeRules("findbugs", [FB], [], [securityJspRules, securityScalaRules])
 //Find Security Bugs
-writeRules("findsecbugs", [FSB], informationnalPatterns + cryptoBugs + majorBugs + criticalBugs, securityJspRules)
+writeRules("findsecbugs", [FSB], informationnalPatterns + cryptoBugs + majorBugs + criticalBugs, [securityJspRules, securityScalaRules])
 writeRules("jsp", [FSB,FB], securityJspRules)
+writeRules("scala", [FSB,FB], securityScalaRules)
 //FB-contrib
 writeRules("fbcontrib", [CONTRIB], [])
 
@@ -258,6 +260,7 @@ totalCount += writeProfile("findbugs-and-fb-contrib", getAllPatternsFromPlugin(F
 totalCount += writeProfile("findbugs-security-audit", getAllPatternsFromPlugin(FSB) - exclusions + findBugsPatterns, securityJspRules)
 writeProfile("findbugs-security-minimal", getAllPatternsFromPlugin(FSB) - informationnalPatterns - exclusions + findBugsPatterns, securityJspRules)
 totalCount += writeProfile("findbugs-security-jsp", securityJspRules)
+totalCount += writeProfile("findbugs-security-scala", securityScalaRules)
 
 
 //unclassifiedBugs = getAllPatternsFromPlugin(FSB) - (informationnalPatterns + cryptoBugs + majorBugs + majorBugsAuditOnly + criticalBugs + findBugsPatterns + exclusions + criticalJspBugs + majorJspBugs)

--- a/generate_profiles/FsbClassifier.groovy
+++ b/generate_profiles/FsbClassifier.groovy
@@ -130,6 +130,15 @@ class FsbClassifier {
           "LDAP_INJECTION",
           "XPATH_INJECTION",
           "XML_DECODER",
+          "SCALA_SENSITIVE_DATA_EXPOSURE",
+          "SCALA_PLAY_SSRF",
+          "SCALA_XSS_TWIRL",
+          "SCALA_XSS_MVC_API",
+          "SCALA_PATH_TRAVERSAL_IN",
+          "SCALA_COMMAND_INJECTION",
+          "SCALA_SQL_INJECTION_SLICK",
+          "SCALA_SQL_INJECTION_ANORM",
+          "PREDICTABLE_RANDOM_SCALA",
           "SCRIPT_ENGINE_INJECTION",
           "SPEL_INJECTION",
           "SQL_INJECTION_SPRING_JDBC",
@@ -152,22 +161,33 @@ class FsbClassifier {
   static //RCE from JSP specific functions (taglibs)
   criticalJspBugs = ["JSP_INCLUDE","JSP_SPRING_EVAL","JSP_XSLT"]
 
-  static exclusions = ['CUSTOM_INJECTION',
-                       'SCALA_SENSITIVE_DATA_EXPOSURE',
-                       'SCALA_PLAY_SSRF',
-                       'SCALA_XSS_TWIRL',
-                       'SCALA_XSS_MVC_API',
-                       'SCALA_PATH_TRAVERSAL_IN',
-                       'SCALA_COMMAND_INJECTION',
+  static
+  criticalScalaBugs = ["SCALA_SENSITIVE_DATA_EXPOSURE",
+                       "SCALA_PLAY_SSRF",
+                       "SCALA_XSS_TWIRL",
+                       "SCALA_XSS_MVC_API",
+                       "SCALA_PATH_TRAVERSAL_IN",
+                       "SCALA_COMMAND_INJECTION",
                        "SCALA_SQL_INJECTION_SLICK",
                        "SCALA_SQL_INJECTION_ANORM",
                        "PREDICTABLE_RANDOM_SCALA"]
+
+  static exclusions = ['CUSTOM_INJECTION']
+//                       'SCALA_SENSITIVE_DATA_EXPOSURE',
+//                       'SCALA_PLAY_SSRF',
+//                       'SCALA_XSS_TWIRL',
+//                       'SCALA_XSS_MVC_API',
+////                       'SCALA_PATH_TRAVERSAL_IN',
+//                       'SCALA_COMMAND_INJECTION',
+//                       "SCALA_SQL_INJECTION_SLICK",
+//                       "SCALA_SQL_INJECTION_ANORM",
+//                       "PREDICTABLE_RANDOM_SCALA"]
 
   static deprecatedRules = []
 
   static String getPriorityFromType(String type,String category) {
     //FSB Specific
-    if (type in criticalBugs || type in criticalJspBugs) return "CRITICAL";
+    if (type in criticalBugs || type in criticalJspBugs || type in criticalScalaBugs) return "CRITICAL";
     if (type in majorBugs || type in cryptoBugs || type in majorJspBugs) return "MAJOR";
     if (type in informationnalPatterns) return "INFO"
 

--- a/src/main/java/org/sonar/plugins/findbugs/FindbugsConfiguration.java
+++ b/src/main/java/org/sonar/plugins/findbugs/FindbugsConfiguration.java
@@ -121,25 +121,12 @@ public class FindbugsConfiguration {
               fileSystem.baseDir().getPath());
     }
 
-
-    boolean hasScalaFiles = fileSystem.hasFiles(fileSystem.predicates().hasLanguage("scala"));
-    boolean hasPrecompiledScala = false;
     for (File classToAnalyze : classFilesToAnalyze) {
       String absolutePath = classToAnalyze.getCanonicalPath();
-      if(hasScalaFiles && !hasPrecompiledScala
-              && (absolutePath.endsWith("_jsp.class") || //Jasper
-              absolutePath.contains("/jsp_servlet/")) //WebLogic
-      ) {
-        hasPrecompiledScala = true;
-      }
+
       if(!"module-info.class".equals(classToAnalyze.getName())) {
         findbugsProject.addFile(absolutePath);
       }
-    }
-
-    if (hasScalaFiles && !hasPrecompiledScala) {
-      LOG.warn("Scala files were found in the current (sub)project ({}) but FindBugs requires their precompiled form. ",
-              fileSystem.baseDir().getPath());
     }
 
     copyLibs();

--- a/src/main/java/org/sonar/plugins/findbugs/FindbugsPlugin.java
+++ b/src/main/java/org/sonar/plugins/findbugs/FindbugsPlugin.java
@@ -24,6 +24,8 @@ import org.sonar.api.batch.fs.FilePredicate;
 import org.sonar.api.batch.fs.FilePredicates;
 import org.sonar.plugins.findbugs.language.Jsp;
 import org.sonar.plugins.findbugs.language.JspSyntaxSensor;
+import org.sonar.plugins.findbugs.language.scala.Scala;
+import org.sonar.plugins.findbugs.language.scala.ScalaSensor;
 import org.sonar.plugins.findbugs.profiles.*;
 import org.sonar.plugins.findbugs.resource.ByteCodeResourceLocator;
 import org.sonar.plugins.findbugs.rules.*;
@@ -35,7 +37,7 @@ import java.util.stream.Collectors;
 public class FindbugsPlugin implements Plugin {
 
     public static final String SUPPORTED_JVM_LANGUAGES[] = {
-            Java.KEY, Jsp.KEY, "scala", "clojure"
+            Java.KEY, Jsp.KEY, Scala.KEY, "clojure"
     };
 
     public static final String SUPPORTED_JVM_LANGUAGES_EXTENSIONS[] = {
@@ -56,6 +58,9 @@ public class FindbugsPlugin implements Plugin {
             Jsp.class,
             JspSyntaxSensor.class,
 
+            Scala.class,
+            ScalaSensor.class,
+
             FindbugsSensor.class,
             FindbugsProfileExporter.class,
             FindbugsProfileImporter.class,
@@ -67,6 +72,7 @@ public class FindbugsPlugin implements Plugin {
             FindbugsSecurityAuditProfile.class,
             FindbugsSecurityMinimalProfile.class,
             FindbugsSecurityJspProfile.class,
+            FindbugsSecurityScalaProfile.class,
 
             FindbugsRulesDefinition.class,
             FbContribRulesDefinition.class,

--- a/src/main/java/org/sonar/plugins/findbugs/FindbugsPlugin.java
+++ b/src/main/java/org/sonar/plugins/findbugs/FindbugsPlugin.java
@@ -72,6 +72,7 @@ public class FindbugsPlugin implements Plugin {
             FbContribRulesDefinition.class,
             FindSecurityBugsRulesDefinition.class,
             FindSecurityBugsJspRulesDefinition.class,
+            FindSecurityBugsScalaRulesDefinition.class,
             ByteCodeResourceLocator.class));
   }
 }

--- a/src/main/java/org/sonar/plugins/findbugs/FindbugsProfileImporter.java
+++ b/src/main/java/org/sonar/plugins/findbugs/FindbugsProfileImporter.java
@@ -34,6 +34,7 @@ import org.sonar.api.rules.RulePriority;
 import org.sonar.api.rules.RuleQuery;
 import org.sonar.api.utils.ValidationMessages;
 import org.sonar.plugins.findbugs.language.Jsp;
+import org.sonar.plugins.findbugs.language.scala.Scala;
 import org.sonar.plugins.findbugs.rules.*;
 import org.sonar.plugins.findbugs.xml.FindBugsFilter;
 import org.sonar.plugins.java.Java;
@@ -49,7 +50,7 @@ public class FindbugsProfileImporter extends ProfileImporter {
 
   public FindbugsProfileImporter(RuleFinder ruleFinder) {
     super(FindbugsRulesDefinition.REPOSITORY_KEY, FindbugsConstants.PLUGIN_NAME);
-    setSupportedLanguages(Java.KEY, Jsp.KEY);
+    setSupportedLanguages(Java.KEY, Jsp.KEY, Scala.KEY);
     this.ruleFinder = ruleFinder;
   }
 

--- a/src/main/java/org/sonar/plugins/findbugs/FindbugsProfileImporter.java
+++ b/src/main/java/org/sonar/plugins/findbugs/FindbugsProfileImporter.java
@@ -34,10 +34,7 @@ import org.sonar.api.rules.RulePriority;
 import org.sonar.api.rules.RuleQuery;
 import org.sonar.api.utils.ValidationMessages;
 import org.sonar.plugins.findbugs.language.Jsp;
-import org.sonar.plugins.findbugs.rules.FbContribRulesDefinition;
-import org.sonar.plugins.findbugs.rules.FindSecurityBugsJspRulesDefinition;
-import org.sonar.plugins.findbugs.rules.FindSecurityBugsRulesDefinition;
-import org.sonar.plugins.findbugs.rules.FindbugsRulesDefinition;
+import org.sonar.plugins.findbugs.rules.*;
 import org.sonar.plugins.findbugs.xml.FindBugsFilter;
 import org.sonar.plugins.java.Java;
 
@@ -85,6 +82,9 @@ public class FindbugsProfileImporter extends ProfileImporter {
           rule = ruleFinder.findByKey(FindSecurityBugsRulesDefinition.REPOSITORY_KEY, patternLevel.getKey());
           if (rule == null) {
             rule = ruleFinder.findByKey(FindSecurityBugsJspRulesDefinition.REPOSITORY_KEY, patternLevel.getKey());
+          }
+          if (rule == null) {
+            rule = ruleFinder.findByKey(FindSecurityBugsScalaRulesDefinition.REPOSITORY_KEY, patternLevel.getKey());
           }
         }
       }
@@ -143,7 +143,8 @@ public class FindbugsProfileImporter extends ProfileImporter {
       ruleFinder.findAll(RuleQuery.create().withRepositoryKey(FindbugsRulesDefinition.REPOSITORY_KEY)),
       ruleFinder.findAll(RuleQuery.create().withRepositoryKey(FbContribRulesDefinition.REPOSITORY_KEY)),
       ruleFinder.findAll(RuleQuery.create().withRepositoryKey(FindSecurityBugsRulesDefinition.REPOSITORY_KEY)),
-      ruleFinder.findAll(RuleQuery.create().withRepositoryKey(FindSecurityBugsJspRulesDefinition.REPOSITORY_KEY)));
+      ruleFinder.findAll(RuleQuery.create().withRepositoryKey(FindSecurityBugsJspRulesDefinition.REPOSITORY_KEY)),
+      ruleFinder.findAll(RuleQuery.create().withRepositoryKey(FindSecurityBugsScalaRulesDefinition.REPOSITORY_KEY)));
   }
 
 }

--- a/src/main/java/org/sonar/plugins/findbugs/FindbugsSensor.java
+++ b/src/main/java/org/sonar/plugins/findbugs/FindbugsSensor.java
@@ -51,7 +51,8 @@ public class FindbugsSensor implements Sensor {
   private static final Logger LOG = LoggerFactory.getLogger(FindbugsSensor.class);
 
   public static final String[] REPOS = {FindbugsRulesDefinition.REPOSITORY_KEY, FbContribRulesDefinition.REPOSITORY_KEY,
-          FindSecurityBugsRulesDefinition.REPOSITORY_KEY, FindSecurityBugsJspRulesDefinition.REPOSITORY_KEY
+          FindSecurityBugsRulesDefinition.REPOSITORY_KEY, FindSecurityBugsJspRulesDefinition.REPOSITORY_KEY,
+          FindSecurityBugsScalaRulesDefinition.REPOSITORY_KEY
   };
 
   private List<String> repositories = new ArrayList<String>();

--- a/src/main/java/org/sonar/plugins/findbugs/FindbugsSensor.java
+++ b/src/main/java/org/sonar/plugins/findbugs/FindbugsSensor.java
@@ -110,10 +110,12 @@ public class FindbugsSensor implements Sensor {
     return hasActiveRules("findsecbugs");
   }
 
+  private boolean hasActiveFindSecScalaBugsRules() { return hasActiveRules("findsecbugs-scala"); }
+
   @Override
   public void execute(SensorContext context) {
 
-    if (!hasActiveFindbugsRules() && !hasActiveFbContribRules() && !hasActiveFindSecBugsRules()) {
+    if (!hasActiveFindbugsRules() && !hasActiveFbContribRules() && !hasActiveFindSecBugsRules() && !hasActiveFindSecScalaBugsRules()) {
       return;
     }
 

--- a/src/main/java/org/sonar/plugins/findbugs/language/scala/Scala.java
+++ b/src/main/java/org/sonar/plugins/findbugs/language/scala/Scala.java
@@ -1,0 +1,45 @@
+package org.sonar.plugins.findbugs.language.scala;
+
+import com.google.common.collect.Lists;
+import org.apache.commons.lang.StringUtils;
+import org.sonar.api.config.Configuration;
+import org.sonar.api.resources.AbstractLanguage;
+
+import java.util.List;
+
+public class Scala extends AbstractLanguage {
+
+    public static final String KEY = "scala";
+
+    public static final String NAME = "Scala";
+
+    public static final String FILE_SUFFIXES_KEY = "sonar.scala.file.suffixes";
+
+    public static final String DEFAULT_FILE_SUFFIXES = ".scala";
+
+    private final Configuration config;
+
+    public Scala(Configuration config) {
+        super(KEY, NAME);
+        this.config = config;
+    }
+
+    private static String[] filterEmptyStrings(String[] stringArray) {
+        List<String> nonEmptyStrings = Lists.newArrayList();
+        for (String string : stringArray) {
+            if (StringUtils.isNotBlank(string.trim())) {
+                nonEmptyStrings.add(string.trim());
+            }
+        }
+        return nonEmptyStrings.toArray(new String[nonEmptyStrings.size()]);
+    }
+
+    @Override
+    public String[] getFileSuffixes() {
+        String[] suffixes = filterEmptyStrings(config.getStringArray(FILE_SUFFIXES_KEY));
+        if (suffixes.length == 0) {
+            suffixes = StringUtils.split(DEFAULT_FILE_SUFFIXES, ",");
+        }
+        return suffixes;
+    }
+}

--- a/src/main/java/org/sonar/plugins/findbugs/language/scala/ScalaSensor.java
+++ b/src/main/java/org/sonar/plugins/findbugs/language/scala/ScalaSensor.java
@@ -1,0 +1,20 @@
+package org.sonar.plugins.findbugs.language.scala;
+
+import org.sonar.api.batch.fs.FileSystem;
+import org.sonar.api.batch.rule.ActiveRules;
+import org.sonar.api.batch.sensor.SensorContext;
+import org.sonar.api.profiles.RulesProfile;
+import org.sonar.plugins.findbugs.FindbugsExecutor;
+import org.sonar.plugins.findbugs.FindbugsSensor;
+import org.sonar.plugins.findbugs.resource.ByteCodeResourceLocator;
+import org.sonar.plugins.findbugs.rules.FindSecurityBugsScalaRulesDefinition;
+import org.sonar.plugins.java.api.JavaResourceLocator;
+
+public class ScalaSensor extends FindbugsSensor {
+
+    public ScalaSensor(RulesProfile profile, ActiveRules ruleFinder, SensorContext sensorContext, FindbugsExecutor executor, JavaResourceLocator javaResourceLocator, FileSystem fs, ByteCodeResourceLocator byteCodeResourceLocator) {
+        super(profile, ruleFinder, sensorContext, executor, javaResourceLocator, fs, byteCodeResourceLocator);
+        super.registerRepositories(FindSecurityBugsScalaRulesDefinition.REPOSITORY_KEY,
+                FindSecurityBugsScalaRulesDefinition.REPOSITORY_KEY);
+    }
+}

--- a/src/main/java/org/sonar/plugins/findbugs/profiles/FindbugsSecurityScalaProfile.java
+++ b/src/main/java/org/sonar/plugins/findbugs/profiles/FindbugsSecurityScalaProfile.java
@@ -1,0 +1,51 @@
+/*
+ * SonarQube Findbugs Plugin
+ * Copyright (C) 2012 SonarSource
+ * sonarqube@googlegroups.com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
+ */
+package org.sonar.plugins.findbugs.profiles;
+
+import org.sonar.api.profiles.ProfileDefinition;
+import org.sonar.api.profiles.RulesProfile;
+import org.sonar.api.utils.ValidationMessages;
+import org.sonar.plugins.findbugs.FindbugsProfileImporter;
+import org.sonar.plugins.findbugs.language.Jsp;
+import org.sonar.plugins.findbugs.language.scala.Scala;
+
+import java.io.InputStreamReader;
+import java.io.Reader;
+
+public class FindbugsSecurityScalaProfile extends ProfileDefinition {
+
+    private static final String FINDBUGS_SECURITY_SCALA_PROFILE_NAME = "FindBugs Security Scala";
+    private final FindbugsProfileImporter importer;
+
+    public FindbugsSecurityScalaProfile(FindbugsProfileImporter importer) {
+        this.importer = importer;
+    }
+
+    @Override
+    public RulesProfile createProfile(ValidationMessages messages) {
+        Reader findbugsProfile = new InputStreamReader(this.getClass().getResourceAsStream(
+                "/org/sonar/plugins/findbugs/profile-findbugs-security-scala.xml"));
+        RulesProfile profile = importer.importProfile(findbugsProfile, messages);
+        profile.setLanguage(Scala.KEY);
+        profile.setName(FINDBUGS_SECURITY_SCALA_PROFILE_NAME);
+        return profile;
+    }
+
+}

--- a/src/main/java/org/sonar/plugins/findbugs/rules/FindSecurityBugsScalaRulesDefinition.java
+++ b/src/main/java/org/sonar/plugins/findbugs/rules/FindSecurityBugsScalaRulesDefinition.java
@@ -2,6 +2,7 @@ package org.sonar.plugins.findbugs.rules;
 
 import org.sonar.api.server.rule.RulesDefinition;
 import org.sonar.api.server.rule.RulesDefinitionXmlLoader;
+import org.sonar.plugins.findbugs.language.scala.Scala;
 
 public class FindSecurityBugsScalaRulesDefinition implements RulesDefinition {
     public static final String REPOSITORY_KEY = "findsecbugs-scala";
@@ -10,7 +11,7 @@ public class FindSecurityBugsScalaRulesDefinition implements RulesDefinition {
     @Override
     public void define(Context context) {
         NewRepository repositoryJsp = context
-                .createRepository(REPOSITORY_KEY, "scala")
+                .createRepository(REPOSITORY_KEY, Scala.KEY)
                 .setName(REPOSITORY_SCALA_NAME);
 
         RulesDefinitionXmlLoader ruleLoaderJsp = new RulesDefinitionXmlLoader();

--- a/src/main/java/org/sonar/plugins/findbugs/rules/FindSecurityBugsScalaRulesDefinition.java
+++ b/src/main/java/org/sonar/plugins/findbugs/rules/FindSecurityBugsScalaRulesDefinition.java
@@ -1,0 +1,20 @@
+package org.sonar.plugins.findbugs.rules;
+
+import org.sonar.api.server.rule.RulesDefinition;
+import org.sonar.api.server.rule.RulesDefinitionXmlLoader;
+
+public class FindSecurityBugsScalaRulesDefinition implements RulesDefinition {
+    public static final String REPOSITORY_KEY = "findsecbugs-scala";
+    public static final String REPOSITORY_SCALA_NAME = "Find Security Bugs (Scala)";
+
+    @Override
+    public void define(Context context) {
+        NewRepository repositoryJsp = context
+                .createRepository(REPOSITORY_KEY, "scala")
+                .setName(REPOSITORY_SCALA_NAME);
+
+        RulesDefinitionXmlLoader ruleLoaderJsp = new RulesDefinitionXmlLoader();
+        ruleLoaderJsp.load(repositoryJsp, FindSecurityBugsRulesDefinition.class.getResourceAsStream("/org/sonar/plugins/findbugs/rules-scala.xml"), "UTF-8");
+        repositoryJsp.done();
+    }
+}

--- a/src/main/resources/org/sonar/plugins/findbugs/profile-findbugs-security-scala.xml
+++ b/src/main/resources/org/sonar/plugins/findbugs/profile-findbugs-security-scala.xml
@@ -1,0 +1,29 @@
+<FindBugsFilter><!-- This file is auto-generated. -->
+  <Match>
+    <Bug pattern='SCALA_PATH_TRAVERSAL_IN' />
+  </Match>
+  <Match>
+    <Bug pattern='SCALA_COMMAND_INJECTION' />
+  </Match>
+  <Match>
+    <Bug pattern='SCALA_SQL_INJECTION_SLICK' />
+  </Match>
+  <Match>
+    <Bug pattern='SCALA_SQL_INJECTION_ANORM' />
+  </Match>
+  <Match>
+    <Bug pattern='SCALA_SENSITIVE_DATA_EXPOSURE' />
+  </Match>
+  <Match>
+    <Bug pattern='SCALA_PLAY_SSRF' />
+  </Match>
+  <Match>
+    <Bug pattern='SCALA_XSS_TWIRL' />
+  </Match>
+  <Match>
+    <Bug pattern='SCALA_XSS_MVC_API' />
+  </Match>
+  <Match>
+    <Bug pattern='PREDICTABLE_RANDOM_SCALA' />
+  </Match>
+</FindBugsFilter>

--- a/src/main/resources/org/sonar/plugins/findbugs/rules-scala.xml
+++ b/src/main/resources/org/sonar/plugins/findbugs/rules-scala.xml
@@ -1,0 +1,350 @@
+<rules><!-- This file is auto-generated. -->
+    <rule key='SCALA_PATH_TRAVERSAL_IN' priority='CRITICAL'>
+        <name>Potential Path Traversal (file read)</name>
+        <configKey>SCALA_PATH_TRAVERSAL_IN</configKey>
+        <description>
+            &lt;p&gt;A file is opened to read its content. The filename comes from an &lt;b&gt;input&lt;/b&gt; parameter.
+                    If an unfiltered parameter is passed to this file API, files from an arbitrary filesystem location could be read.&lt;/p&gt;
+                &lt;p&gt;This rule identifies &lt;b&gt;potential&lt;/b&gt; path traversal vulnerabilities. In many cases, the constructed file path cannot be controlled
+                    by the user. If that is the case, the reported instance is a false positive.&lt;/p&gt;
+                &lt;br&gt;
+
+                &lt;p&gt;
+                    &lt;b&gt;Vulnerable Code:&lt;/b&gt;&lt;br&gt;
+                &lt;/p&gt;&lt;pre&gt;def getWordList(value:String) = Action {
+                if (!Files.exists(Paths.get("public/lists/" + value))) {
+                NotFound("File not found")
+                } else {
+                val result = Source.fromFile("public/lists/" + value).getLines().mkString // Weak point
+                Ok(result)
+                }
+                }&lt;/pre&gt;
+                &lt;p&gt;&lt;/p&gt;
+                &lt;br&gt;
+
+                &lt;p&gt;
+                    &lt;b&gt;Solution:&lt;/b&gt;&lt;br&gt;
+                &lt;/p&gt;&lt;pre&gt;import org.apache.commons.io.FilenameUtils;
+
+                def getWordList(value:String) = Action {
+                val filename = "public/lists/" + FilenameUtils.getName(value)
+
+                if (!Files.exists(Paths.get(filename))) {
+                NotFound("File not found")
+                } else {
+                val result = Source.fromFile(filename).getLines().mkString // Fix
+                Ok(result)
+                }
+                }&lt;/pre&gt;
+                &lt;p&gt;&lt;/p&gt;
+                &lt;br&gt;
+                &lt;p&gt;
+                    &lt;b&gt;References&lt;/b&gt;&lt;br&gt;
+                    &lt;a href="http://projects.webappsec.org/w/page/13246952/Path%20Traversal"&gt;WASC: Path Traversal&lt;/a&gt;&lt;br&gt;
+                    &lt;a href="https://www.owasp.org/index.php/Path_Traversal"&gt;OWASP: Path Traversal&lt;/a&gt;&lt;br&gt;
+                    &lt;a href="http://capec.mitre.org/data/definitions/126.html"&gt;CAPEC-126: Path Traversal&lt;/a&gt;&lt;br&gt;
+                    &lt;a href="http://cwe.mitre.org/data/definitions/22.html"&gt;CWE-22: Improper Limitation of a Pathname to a Restricted Directory ('Path Traversal')&lt;/a&gt;
+                &lt;/p&gt;
+        </description>
+        <tag>scala</tag>
+        <tag>security</tag>
+    </rule>
+    <rule key='SCALA_COMMAND_INJECTION' priority='CRITICAL'>
+        <name>Potential Command Injection (Scala)</name>
+        <configKey>SCALA_COMMAND_INJECTION</configKey>
+        <description>
+            &lt;p&gt;The highlighted API is used to execute a system command. If unfiltered input is passed to this API, it can lead to arbitrary command execution.&lt;/p&gt;
+            &lt;br&gt;
+            &lt;p&gt;
+                &lt;b&gt;Vulnerable Code:&lt;/b&gt;&lt;br&gt;
+            &lt;/p&gt;&lt;pre&gt;def executeCommand(value:String) = Action {
+            val result = value.!
+            Ok("Result:\n"+result)
+            }&lt;/pre&gt;
+            &lt;p&gt;&lt;/p&gt;
+            &lt;p&gt;
+                &lt;b&gt;References&lt;/b&gt;&lt;br&gt;
+                &lt;a href="https://www.owasp.org/index.php/Command_Injection"&gt;OWASP: Command Injection&lt;/a&gt;&lt;br&gt;
+                &lt;a href="https://www.owasp.org/index.php/Top_10_2013-A1-Injection"&gt;OWASP: Top 10 2013-A1-Injection&lt;/a&gt;&lt;br&gt;
+                &lt;a href="http://cwe.mitre.org/data/definitions/78.html"&gt;CWE-78: Improper Neutralization of Special Elements used in an OS Command ('OS Command Injection')&lt;/a&gt;
+            &lt;/p&gt;
+        </description>
+        <tag>scala</tag>
+        <tag>security</tag>
+    </rule>
+    <rule key='SCALA_SQL_INJECTION_SLICK' priority='CRITICAL'>
+        <name>Potential Scala Slick Injection</name>
+        <configKey>SCALA_SQL_INJECTION_SLICK</configKey>
+        <description>
+                &lt;p&gt;
+                    The input values included in SQL queries need to be passed in safely.
+                    Bind variables in prepared statements can be used to easily mitigate the risk of SQL injection.
+                &lt;/p&gt;
+
+                &lt;p&gt;
+                    &lt;b&gt;Vulnerable Code:&lt;/b&gt;&lt;br&gt;
+                &lt;/p&gt;&lt;pre&gt;db.run {
+                sql"select * from people where name = '#$value'".as[Person]
+                }&lt;/pre&gt;
+                &lt;p&gt;&lt;/p&gt;
+                &lt;p&gt;
+                    &lt;b&gt;Solution:&lt;/b&gt;&lt;br&gt;
+                &lt;/p&gt;&lt;pre&gt;db.run {
+                sql"select * from people where name = $value".as[Person]
+                }&lt;/pre&gt;
+                &lt;p&gt;&lt;/p&gt;
+                &lt;br&gt;
+
+                &lt;b&gt;References (SQL injection)&lt;/b&gt;&lt;br&gt;
+                &lt;a href="http://projects.webappsec.org/w/page/13246963/SQL%20Injection"&gt;WASC-19: SQL Injection&lt;/a&gt;&lt;br&gt;
+                &lt;a href="http://capec.mitre.org/data/definitions/66.html"&gt;CAPEC-66: SQL Injection&lt;/a&gt;&lt;br&gt;
+                &lt;a href="http://cwe.mitre.org/data/definitions/89.html"&gt;CWE-89: Improper Neutralization of Special Elements used in an SQL Command ('SQL Injection')&lt;/a&gt;&lt;br&gt;
+                &lt;a href="https://www.owasp.org/index.php/Top_10_2013-A1-Injection"&gt;OWASP: Top 10 2013-A1-Injection&lt;/a&gt;&lt;br&gt;
+                &lt;a href="https://www.owasp.org/index.php/SQL_Injection_Prevention_Cheat_Sheet"&gt;OWASP: SQL Injection Prevention Cheat Sheet&lt;/a&gt;&lt;br&gt;
+                &lt;a href="https://www.owasp.org/index.php/Query_Parameterization_Cheat_Sheet"&gt;OWASP: Query Parameterization Cheat Sheet&lt;/a&gt;&lt;br&gt;
+                &lt;p&gt;&lt;/p&gt;
+        </description>
+        <tag>scala</tag>
+        <tag>security</tag>
+    </rule>
+    <rule key='SCALA_SQL_INJECTION_ANORM' priority='CRITICAL'>
+        <name>Potential Scala Anorm Injection</name>
+        <configKey>SCALA_SQL_INJECTION_ANORM</configKey>
+        <description>
+                &lt;p&gt;
+                    The input values included in SQL queries need to be passed in safely.
+                    Bind variables in prepared statements can be used to easily mitigate the risk of SQL injection.
+                &lt;/p&gt;
+
+                &lt;p&gt;
+                    &lt;b&gt;Vulnerable Code:&lt;/b&gt;&lt;br&gt;
+                &lt;/p&gt;&lt;pre&gt;val peopleParser = Macro.parser[Person]("id", "name", "age")
+
+                DB.withConnection { implicit c =&gt;
+                val people: List[Person] = SQL("select * from people where name = '" + value + "'").as(peopleParser.*)
+                }&lt;/pre&gt;
+                &lt;p&gt;&lt;/p&gt;
+                &lt;p&gt;
+                    &lt;b&gt;Solution:&lt;/b&gt;&lt;br&gt;
+                &lt;/p&gt;&lt;pre&gt;val peopleParser = Macro.parser[Person]("id", "name", "age")
+
+                DB.withConnection { implicit c =&gt;
+                val people: List[Person] = SQL"select * from people where name = $value".as(peopleParser.*)
+                }&lt;/pre&gt;
+                &lt;p&gt;&lt;/p&gt;
+                &lt;br&gt;
+
+                &lt;b&gt;References (SQL injection)&lt;/b&gt;&lt;br&gt;
+                &lt;a href="http://projects.webappsec.org/w/page/13246963/SQL%20Injection"&gt;WASC-19: SQL Injection&lt;/a&gt;&lt;br&gt;
+                &lt;a href="http://capec.mitre.org/data/definitions/66.html"&gt;CAPEC-66: SQL Injection&lt;/a&gt;&lt;br&gt;
+                &lt;a href="http://cwe.mitre.org/data/definitions/89.html"&gt;CWE-89: Improper Neutralization of Special Elements used in an SQL Command ('SQL Injection')&lt;/a&gt;&lt;br&gt;
+                &lt;a href="https://www.owasp.org/index.php/Top_10_2013-A1-Injection"&gt;OWASP: Top 10 2013-A1-Injection&lt;/a&gt;&lt;br&gt;
+                &lt;a href="https://www.owasp.org/index.php/SQL_Injection_Prevention_Cheat_Sheet"&gt;OWASP: SQL Injection Prevention Cheat Sheet&lt;/a&gt;&lt;br&gt;
+                &lt;a href="https://www.owasp.org/index.php/Query_Parameterization_Cheat_Sheet"&gt;OWASP: Query Parameterization Cheat Sheet&lt;/a&gt;&lt;br&gt;
+                &lt;p&gt;&lt;/p&gt;
+        </description>
+        <tag>scala</tag>
+        <tag>security</tag>
+    </rule>
+    <rule key='SCALA_SENSITIVE_DATA_EXPOSURE' priority='CRITICAL'>
+        <name>Potential information leakage in Scala Play</name>
+        <configKey>SCALA_SENSITIVE_DATA_EXPOSURE</configKey>
+        <description>
+                &lt;p&gt;
+                    Applications can unintentionally leak information about their configuration, internal workings, or violate privacy through a
+                    variety of application problems. &lt;sup&gt;[1]&lt;/sup&gt; Pages that provide different responses based on the validity of the data can
+                    lead to Information Leakage; specifically when data deemed confidential is being revealed as a result of the web application's
+                    design. &lt;sup&gt;[2]&lt;/sup&gt;
+                &lt;/p&gt;
+                &lt;p&gt;
+                    Examples of sensitive data includes (but is not limited to): API keys, passwords, product versions or environment configurations.
+                &lt;/p&gt;
+                &lt;p&gt;
+                    &lt;b&gt;Code at risk:&lt;/b&gt;&lt;br&gt;
+                &lt;/p&gt;&lt;pre&gt;def doGet(value:String) = Action {
+                val configElement = configuration.underlying.getString(value)
+
+                Ok("Hello "+ configElement +" !")
+                }&lt;/pre&gt;
+                &lt;p&gt;&lt;/p&gt;
+                &lt;p&gt;
+                    Application configuration elements should not be sent in the response content and users should not be allowed to control which
+                    configuration elements will be used by the code.
+                &lt;/p&gt;
+                &lt;b&gt;References&lt;/b&gt;&lt;br&gt;
+                &lt;a href="https://www.owasp.org/index.php/Top_10_2013-A6-Sensitive_Data_Exposure"&gt;OWASP: Top 10 2013-A6-Sensitive Data Exposure&lt;/a&gt;&lt;br&gt;
+                [1] &lt;a href="https://www.owasp.org/index.php/Top_10_2007-Information_Leakage_and_Improper_Error_Handling"&gt;OWASP: Top 10 2007-Information Leakage and Improper Error Handling&lt;/a&gt;&lt;br&gt;
+                [2] &lt;a href="http://projects.webappsec.org/w/page/13246936/Information%20Leakage"&gt;WASC-13: Information Leakage&lt;/a&gt;&lt;br&gt;
+                &lt;a href="https://cwe.mitre.org/data/definitions/200.html"&gt;CWE-200: Information Exposure&lt;/a&gt;&lt;br&gt;
+                &lt;p&gt;&lt;/p&gt;
+        </description>
+        <tag>scala</tag>
+        <tag>security</tag>
+    </rule>
+    <rule key='SCALA_PLAY_SSRF' priority='CRITICAL'>
+        <name>Scala Play Server-Side Request Forgery (SSRF)</name>
+        <configKey>SCALA_PLAY_SSRF</configKey>
+        <description>
+                &lt;p&gt;
+                    Server-Side Request Forgery occur when a web server executes a request to a user supplied destination
+                    parameter that is not validated. Such vulnerabilities could allow an attacker to access internal services
+                    or to launch attacks from your web server.
+                &lt;/p&gt;
+                &lt;p&gt;
+                    &lt;b&gt;Vulnerable Code:&lt;/b&gt;
+                &lt;/p&gt;&lt;pre&gt;def doGet(value:String) = Action {
+                WS.url(value).get().map { response =&gt;
+                Ok(response.body)
+                }
+                }&lt;/pre&gt;
+                &lt;p&gt;&lt;/p&gt;
+                &lt;p&gt;
+                    &lt;b&gt;Solution/Countermeasures:&lt;/b&gt;&lt;br&gt;
+                &lt;/p&gt;&lt;ul&gt;
+                &lt;li&gt;Don't accept request destinations from users&lt;/li&gt;
+                &lt;li&gt;Accept a destination key, and use it to look up the target (legal) destination&lt;/li&gt;
+                &lt;li&gt;White list URLs (if possible)&lt;/li&gt;
+                &lt;li&gt;Validate that the beginning of the URL is part of a white list&lt;/li&gt;
+            &lt;/ul&gt;
+                &lt;p&gt;&lt;/p&gt;
+                &lt;br&gt;
+                &lt;p&gt;
+                    &lt;b&gt;References&lt;/b&gt;&lt;br&gt;
+                    &lt;a href="https://cwe.mitre.org/data/definitions/918.html"&gt;CWE-918: Server-Side Request Forgery (SSRF)&lt;/a&gt;&lt;br&gt;
+                    &lt;a href="https://www.bishopfox.com/blog/2015/04/vulnerable-by-design-understanding-server-side-request-forgery/"&gt;Understanding Server-Side Request Forgery&lt;/a&gt;&lt;br&gt;
+                &lt;/p&gt;
+        </description>
+        <tag>scala</tag>
+        <tag>security</tag>
+    </rule>
+    <rule key='SCALA_XSS_TWIRL' priority='CRITICAL'>
+        <name>Potential XSS in Scala Twirl template engine</name>
+        <configKey>SCALA_XSS_TWIRL</configKey>
+        <description>
+                &lt;p&gt;
+                    A potential XSS was found. It could be used to execute unwanted JavaScript in a client's browser. (See references)
+                &lt;/p&gt;
+                &lt;p&gt;
+                    &lt;b&gt;Vulnerable Code:&lt;/b&gt;
+                &lt;/p&gt;&lt;pre&gt;@(value: Html)
+
+                @value&lt;/pre&gt;
+                &lt;p&gt;&lt;/p&gt;
+                &lt;p&gt;
+                    &lt;b&gt;Solution:&lt;/b&gt;
+                &lt;/p&gt;&lt;pre&gt;@(value: String)
+
+                @value&lt;/pre&gt;
+                &lt;p&gt;&lt;/p&gt;
+                &lt;p&gt;
+                    The best defense against XSS is context sensitive output encoding like the example above. There are typically 4 contexts to consider:
+                    HTML, JavaScript, CSS (styles), and URLs. Please follow the XSS protection rules defined in the OWASP XSS Prevention Cheat Sheet,
+                    which explains these defenses in significant detail.
+                &lt;/p&gt;
+                &lt;br&gt;
+                &lt;p&gt;
+                    &lt;b&gt;References&lt;/b&gt;&lt;br&gt;
+                    &lt;a href="http://projects.webappsec.org/w/page/13246920/Cross%20Site%20Scripting"&gt;WASC-8: Cross Site Scripting&lt;/a&gt;&lt;br&gt;
+                    &lt;a href="https://www.owasp.org/index.php/XSS_%28Cross_Site_Scripting%29_Prevention_Cheat_Sheet"&gt;OWASP: XSS Prevention Cheat Sheet&lt;/a&gt;&lt;br&gt;
+                    &lt;a href="https://www.owasp.org/index.php/Top_10_2013-A3-Cross-Site_Scripting_%28XSS%29"&gt;OWASP: Top 10 2013-A3: Cross-Site Scripting (XSS)&lt;/a&gt;&lt;br&gt;
+                    &lt;a href="http://cwe.mitre.org/data/definitions/79.html"&gt;CWE-79: Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')&lt;/a&gt;&lt;br&gt;
+                    &lt;a href="https://code.google.com/p/owasp-java-encoder/"&gt;OWASP Java Encoder&lt;/a&gt;&lt;br&gt;
+                &lt;/p&gt;
+        </description>
+        <tag>scala</tag>
+        <tag>security</tag>
+    </rule>
+    <rule key='SCALA_XSS_MVC_API' priority='CRITICAL'>
+        <name>Potential XSS in Scala MVC API engine</name>
+        <configKey>SCALA_XSS_MVC_API</configKey>
+        <description>
+                &lt;p&gt;
+                    A potential XSS was found. It could be used to execute unwanted JavaScript in a client's browser. (See references)
+                &lt;/p&gt;
+                &lt;p&gt;
+                    &lt;b&gt;Vulnerable Code:&lt;/b&gt;
+                &lt;/p&gt;&lt;pre&gt;def doGet(value:String) = Action {
+                Ok("Hello " + value + " !").as("text/html")
+                }&lt;/pre&gt;
+                &lt;p&gt;&lt;/p&gt;
+                &lt;p&gt;
+                    &lt;b&gt;Solution:&lt;/b&gt;
+                &lt;/p&gt;&lt;pre&gt;def doGet(value:String) = Action {
+                Ok("Hello " + Encode.forHtml(value) + " !")
+                }&lt;/pre&gt;
+                &lt;p&gt;&lt;/p&gt;
+                &lt;p&gt;
+                    The best defense against XSS is context sensitive output encoding like the example above. There are typically 4 contexts to consider:
+                    HTML, JavaScript, CSS (styles), and URLs. Please follow the XSS protection rules defined in the OWASP XSS Prevention Cheat Sheet,
+                    which explains these defenses in significant detail.
+                &lt;/p&gt;
+                &lt;br&gt;
+                &lt;p&gt;
+                    &lt;b&gt;References&lt;/b&gt;&lt;br&gt;
+                    &lt;a href="http://projects.webappsec.org/w/page/13246920/Cross%20Site%20Scripting"&gt;WASC-8: Cross Site Scripting&lt;/a&gt;&lt;br&gt;
+                    &lt;a href="https://www.owasp.org/index.php/XSS_%28Cross_Site_Scripting%29_Prevention_Cheat_Sheet"&gt;OWASP: XSS Prevention Cheat Sheet&lt;/a&gt;&lt;br&gt;
+                    &lt;a href="https://www.owasp.org/index.php/Top_10_2013-A3-Cross-Site_Scripting_%28XSS%29"&gt;OWASP: Top 10 2013-A3: Cross-Site Scripting (XSS)&lt;/a&gt;&lt;br&gt;
+                    &lt;a href="http://cwe.mitre.org/data/definitions/79.html"&gt;CWE-79: Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')&lt;/a&gt;&lt;br&gt;
+                    &lt;a href="https://code.google.com/p/owasp-java-encoder/"&gt;OWASP Java Encoder&lt;/a&gt;&lt;br&gt;
+                &lt;/p&gt;
+        </description>
+        <tag>scala</tag>
+        <tag>security</tag>
+    </rule>
+    <rule key='PREDICTABLE_RANDOM_SCALA' priority='CRITICAL'>
+        <name>Predictable pseudorandom number generator (Scala)</name>
+        <configKey>PREDICTABLE_RANDOM_SCALA</configKey>
+        <description>
+                &lt;p&gt;The use of a predictable random value can lead to vulnerabilities when used in certain security critical contexts. For example, when the value is used as:&lt;/p&gt;
+                &lt;ul&gt;
+                    &lt;li&gt;a CSRF token: a predictable token can lead to a CSRF attack as an attacker will know the value of the token&lt;/li&gt;
+                    &lt;li&gt;a password reset token (sent by email): a predictable password token can lead to an account takeover, since an attacker will guess the URL of the change password form&lt;/li&gt;
+                    &lt;li&gt;any other secret value&lt;/li&gt;
+                &lt;/ul&gt;
+                &lt;p&gt;
+                    A quick fix could be to replace the use of &lt;b&gt;java.util.Random&lt;/b&gt; with something stronger, such as &lt;b&gt;java.security.SecureRandom&lt;/b&gt;.
+                &lt;/p&gt;
+                &lt;p&gt;
+                    &lt;b&gt;Vulnerable Code:&lt;/b&gt;&lt;br&gt;
+                &lt;/p&gt;&lt;pre&gt;import scala.util.Random
+
+                def generateSecretToken() {
+                val result = Seq.fill(16)(Random.nextInt)
+                return result.map("%02x" format _).mkString
+                }&lt;/pre&gt;
+                &lt;p&gt;&lt;/p&gt;
+                &lt;p&gt;
+                    &lt;b&gt;Solution:&lt;/b&gt;
+                &lt;/p&gt;&lt;pre&gt;import java.security.SecureRandom
+
+                def generateSecretToken() {
+                val rand = new SecureRandom()
+                val value = Array.ofDim[Byte](16)
+                rand.nextBytes(value)
+                return value.map("%02x" format _).mkString
+                }&lt;/pre&gt;
+                &lt;p&gt;&lt;/p&gt;
+                &lt;!--&lt;p&gt;
+                &lt;b&gt;Solution:&lt;/b&gt;
+                &lt;pre&gt;import java.security.SecureRandom
+                import scala.util.Random._
+                
+                def generateSecretToken() {
+                    val secRandom = javaRandomToRandom(new SecureRandom())
+                    val result = Seq.fill(16)(secRandom.nextInt)
+                    return result.map("%02x" format _).mkString
+                }&lt;/pre&gt;
+                &lt;/p&gt;--&gt;
+                &lt;br&gt;
+                &lt;p&gt;
+                    &lt;b&gt;References&lt;/b&gt;&lt;br&gt;
+                    &lt;a href="http://jazzy.id.au/default/2010/09/20/cracking_random_number_generators_part_1.html"&gt;Cracking Random Number Generators - Part 1 (http://jazzy.id.au)&lt;/a&gt;&lt;br&gt;
+                    &lt;a href="https://www.securecoding.cert.org/confluence/display/java/MSC02-J.+Generate+strong+random+numbers"&gt;CERT: MSC02-J. Generate strong random numbers&lt;/a&gt;&lt;br&gt;
+                    &lt;a href="http://cwe.mitre.org/data/definitions/330.html"&gt;CWE-330: Use of Insufficiently Random Values&lt;/a&gt;&lt;br&gt;
+                    &lt;a href="http://blog.h3xstream.com/2014/12/predicting-struts-csrf-token-cve-2014.html"&gt;Predicting Struts CSRF Token (Example of real-life vulnerability and exploitation)&lt;/a&gt;
+                &lt;/p&gt;
+        </description>
+        <tag>scala</tag>
+        <tag>security</tag>
+    </rule>
+</rules>

--- a/src/test/java/org/sonar/plugins/findbugs/FindbugsPluginTest.java
+++ b/src/test/java/org/sonar/plugins/findbugs/FindbugsPluginTest.java
@@ -38,7 +38,7 @@ public class FindbugsPluginTest {
     FindbugsPlugin plugin = new FindbugsPlugin();
     plugin.define(ctx);
 
-    assertEquals("extension count", 24, ctx.getExtensions().size());
+    assertEquals("extension count", 27, ctx.getExtensions().size());
   }
 
 }

--- a/src/test/java/org/sonar/plugins/findbugs/FindbugsPluginTest.java
+++ b/src/test/java/org/sonar/plugins/findbugs/FindbugsPluginTest.java
@@ -38,7 +38,7 @@ public class FindbugsPluginTest {
     FindbugsPlugin plugin = new FindbugsPlugin();
     plugin.define(ctx);
 
-    assertEquals("extension count", 23, ctx.getExtensions().size());
+    assertEquals("extension count", 24, ctx.getExtensions().size());
   }
 
 }

--- a/src/test/java/org/sonar/plugins/findbugs/rule/FakeRuleFinder.java
+++ b/src/test/java/org/sonar/plugins/findbugs/rule/FakeRuleFinder.java
@@ -28,10 +28,7 @@ import org.sonar.api.rules.RuleFinder;
 import org.sonar.api.rules.RuleQuery;
 import org.sonar.api.server.rule.RulesDefinition;
 import org.sonar.api.server.rule.RulesDefinition.Context;
-import org.sonar.plugins.findbugs.rules.FbContribRulesDefinition;
-import org.sonar.plugins.findbugs.rules.FindSecurityBugsJspRulesDefinition;
-import org.sonar.plugins.findbugs.rules.FindSecurityBugsRulesDefinition;
-import org.sonar.plugins.findbugs.rules.FindbugsRulesDefinition;
+import org.sonar.plugins.findbugs.rules.*;
 
 import java.util.List;
 
@@ -49,7 +46,7 @@ public class FakeRuleFinder {
   private FakeRuleFinder() {
   }
 
-  private static RuleFinder create(boolean findbugs, boolean fbContrib, boolean findSecBug, boolean findSecBugJsp) {
+  private static RuleFinder create(boolean findbugs, boolean fbContrib, boolean findSecBug, boolean findSecBugJsp, boolean findSecBugScala) {
     RuleFinder ruleFinder = mock(RuleFinder.class);
     RulesDefinition.Context context = new RulesDefinition.Context();
 
@@ -77,23 +74,29 @@ public class FakeRuleFinder {
       configRuleFinderForRepo(ruleFinder, context, FindSecurityBugsJspRulesDefinition.REPOSITORY_KEY);
     }
 
+    if (findSecBugScala) {
+      RulesDefinition rulesDefinition = new FindSecurityBugsScalaRulesDefinition();
+      rulesDefinition.define(context);
+      configRuleFinderForRepo(ruleFinder, context, FindSecurityBugsScalaRulesDefinition.REPOSITORY_KEY);
+    }
+
     return ruleFinder;
   }
 
   public static RuleFinder createWithAllRules() {
-    return create(true, true, true, true);
+    return create(true, true, true, true, true);
   }
 
   public static RuleFinder createWithOnlyFindbugsRules() {
-    return create(true, false, false,false);
+    return create(true, false, false,false, true);
   }
 
   public static RuleFinder createWithOnlyFbContribRules() {
-    return create(false, true, false,false);
+    return create(false, true, false,false,false);
   }
 
   public static RuleFinder createWithOnlyFindSecBugsRules() {
-    return create(false, false, true,false);
+    return create(false, false, true,false, true);
   }
 
   private static void configRuleFinderForRepo(RuleFinder ruleFinder, final Context context, final String repositoryKey) {


### PR DESCRIPTION
Didn't declare Scala language for compatibility reasons (Since that language is declared by other plugin I'm using I don't have to declare this, just use it).
I have followed the way the plugin is written to give support to Scala. The rules are published in Sonarqube, and you can even activate them, also use the profile declared, but the incidences are not found.
Is this a Sonarqube problem? Based on the comment here https://github.com/spotbugs/sonar-findbugs/issues/28#issuecomment-321631793