### PR TITLE
build and test with SonarQube 7.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ env:
   # latest LTS
   - SONAR_VERSION=6.7.6 SONAR_JAVA_VERSION=5.2.0.13398
   # latest releases
-  - SONAR_VERSION=7.4 SONAR_JAVA_VERSION=5.8.0.15699
+  - SONAR_VERSION=7.5 SONAR_JAVA_VERSION=5.9.2.16552
 install:
   # decrypt settings.xml, pubring.gpg and secring.gpg
   - if [ -n "$encrypted_b6710039761a_key" ]; then openssl aes-256-cbc -K $encrypted_b6710039761a_key -iv $encrypted_b6710039761a_iv -in .travis/secrets.tar.enc -out .travis/secrets.tar -d; fi

--- a/src/smoke-test/sonarqube-latest
+++ b/src/smoke-test/sonarqube-latest
@@ -1,7 +1,7 @@
 # Copied from https://github.com/SonarSource/docker-sonarqube/tree/master/7.1 under LGPL
 FROM openjdk:8
 
-ENV SONAR_VERSION=7.4 \
+ENV SONAR_VERSION=7.5 \
     SONARQUBE_HOME=/opt/sonarqube \
     # Database configuration
     # Defaults to using H2

--- a/src/test/java/org/sonar/plugins/findbugs/rule/SimpleActiveRule.java
+++ b/src/test/java/org/sonar/plugins/findbugs/rule/SimpleActiveRule.java
@@ -69,4 +69,11 @@ public class SimpleActiveRule implements ActiveRule {
   public String templateRuleKey() {
     return templateRuleKey;
   }
+
+  /**
+   * Key of the quality profile the rule belongs to. To compile with SonarQube 7.4 and older, we do not annotate this method with {@code @Override} for now.
+   */
+  public String qpKey() {
+    return "quality-profile-key";
+  }
 }


### PR DESCRIPTION
[The docker image for 7.5](https://hub.docker.com/_/sonarqube/) is not available, so we do not update files in `src/smoke-test` in this timing.

I've confirmed that SonarQube 7.5 community edition is packaged with sonar-java 5.9.2.16552.