### PR TITLE
Release 3.9.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,7 @@ deploy:
     skip_cleanup: true
     script: mvn deploy -B -P deploy -Dgpg.skip -s .travis/settings.xml
     on:
-      branch: master
+      branch: release-for-lts
       condition: "$SONAR_VERSION = '6.7'*"
   # deploy STABLE artifact onto Sonatype Nexus
   - provider: script

--- a/README.md
+++ b/README.md
@@ -47,4 +47,4 @@ Findbugs Plugin version|Embedded SpotBugs/Findbugs version|Embedded Findsecbugs 
 3.7                    | 3.1.2 (SpotBugs)                 | 1.7.1                      | 7.2.1sb                   | 1.8|6.7.1|5.1.0.13090
 3.8                    | 3.1.6 (SpotBugs)                 | 1.8.0                      | 7.4.3sb                   | 1.8|6.7.1|5.1.0.13090
 3.9                    | 3.1.8 (SpotBugs)                 | 1.8.0                      | 7.4.3sb                   | 1.8|6.7.1|5.2.0.13398
-3.10-SNAPSHOT          | 3.1.11 (SpotBugs)                | 1.8.0                      | 7.4.3sb                   | 1.8|6.7.1|5.2.0.13398
+3.9.2                  | 3.1.11 (SpotBugs)                | 1.8.0                      | 7.4.3sb                   | 1.8|6.7.1|5.2.0.13398

--- a/README.md
+++ b/README.md
@@ -48,3 +48,5 @@ Findbugs Plugin version|Embedded SpotBugs/Findbugs version|Embedded Findsecbugs 
 3.8                    | 3.1.6 (SpotBugs)                 | 1.8.0                      | 7.4.3sb                   | 1.8|6.7.1|5.1.0.13090
 3.9                    | 3.1.8 (SpotBugs)                 | 1.8.0                      | 7.4.3sb                   | 1.8|6.7.1|5.2.0.13398
 3.9.2                  | 3.1.11 (SpotBugs)                | 1.8.0                      | 7.4.3sb                   | 1.8|6.7.1|5.2.0.13398
+3.9.3-SNAPSHOT         | 3.1.11 (SpotBugs)                | 1.8.0                      | 7.4.3sb                   | 1.8|6.7.1|5.2.0.13398
+

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>com.github.spotbugs</groupId>
   <artifactId>sonar-findbugs-plugin</artifactId>
-  <version>3.10.0-SNAPSHOT</version>
+  <version>3.9.2</version>
   <packaging>sonar-plugin</packaging>
 
   <name>SonarQube SpotBugs Plugin</name>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>com.github.spotbugs</groupId>
   <artifactId>sonar-findbugs-plugin</artifactId>
-  <version>3.9.2</version>
+  <version>3.9.3-SNAPSHOT</version>
   <packaging>sonar-plugin</packaging>
 
   <name>SonarQube SpotBugs Plugin</name>


### PR DESCRIPTION
According to https://github.com/spotbugs/sonar-findbugs/pull/242#issuecomment-458971587, current `master` branch does not support SonarQube 6.7.x LTS. Then before release 3.10, let's release 3.9.2 that can work with  SonarQube 6.7.x LTS.

note: According to that comment, this `release-for-lts` branch could be necessary just for several coming months.

> We also have another LTS version planned in a few months.
