### PR TITLE
Release 3.10 for sonarqube 7.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ env:
   # latest LTS
   - SONAR_VERSION=6.7.6 SONAR_JAVA_VERSION=5.2.0.13398
   # latest releases
-  - SONAR_VERSION=7.5 SONAR_JAVA_VERSION=5.9.2.16552
+  - SONAR_VERSION=7.6 SONAR_JAVA_VERSION=5.10.1.16922
 install:
   # decrypt settings.xml, pubring.gpg and secring.gpg
   - if [ -n "$encrypted_b6710039761a_key" ]; then openssl aes-256-cbc -K $encrypted_b6710039761a_key -iv $encrypted_b6710039761a_iv -in .travis/secrets.tar.enc -out .travis/secrets.tar -d; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,6 @@ jdk:
 services:
   - docker
 env:
-  # latest LTS
-  - SONAR_VERSION=6.7.6 SONAR_JAVA_VERSION=5.2.0.13398
   # latest releases
   - SONAR_VERSION=7.6 SONAR_JAVA_VERSION=5.10.1.16922
 install:
@@ -18,9 +16,6 @@ script:
   - mvn verify -B -e -V -Dsonar.version=$SONAR_VERSION -Dsonar-java.version=$SONAR_JAVA_VERSION
 jobs:
   include:
-    - stage: smoke-test
-      script:
-        - 'mvn package && docker-compose -f src/smoke-test/docker-compose.yml --project-directory . run --rm test-lts'
     - script:
         - 'mvn package && docker-compose -f src/smoke-test/docker-compose.yml --project-directory . run --rm test-latest'
     - stage: analysis

--- a/README.md
+++ b/README.md
@@ -47,4 +47,4 @@ Findbugs Plugin version|Embedded SpotBugs/Findbugs version|Embedded Findsecbugs 
 3.7                    | 3.1.2 (SpotBugs)                 | 1.7.1                      | 7.2.1sb                   | 1.8|6.7.1|5.1.0.13090
 3.8                    | 3.1.6 (SpotBugs)                 | 1.8.0                      | 7.4.3sb                   | 1.8|6.7.1|5.1.0.13090
 3.9                    | 3.1.8 (SpotBugs)                 | 1.8.0                      | 7.4.3sb                   | 1.8|6.7.1|5.2.0.13398
-3.10-SNAPSHOT          | 3.1.10 (SpotBugs)                | 1.8.0                      | 7.4.3sb                   | 1.8|6.7.1|5.2.0.13398
+3.10-SNAPSHOT          | 3.1.11 (SpotBugs)                | 1.8.0                      | 7.4.3sb                   | 1.8|6.7.1|5.2.0.13398

--- a/README.md
+++ b/README.md
@@ -47,4 +47,4 @@ Findbugs Plugin version|Embedded SpotBugs/Findbugs version|Embedded Findsecbugs 
 3.7                    | 3.1.2 (SpotBugs)                 | 1.7.1                      | 7.2.1sb                   | 1.8|6.7.1|5.1.0.13090
 3.8                    | 3.1.6 (SpotBugs)                 | 1.8.0                      | 7.4.3sb                   | 1.8|6.7.1|5.1.0.13090
 3.9                    | 3.1.8 (SpotBugs)                 | 1.8.0                      | 7.4.3sb                   | 1.8|6.7.1|5.2.0.13398
-3.10-SNAPSHOT          | 3.1.11 (SpotBugs)                | 1.8.0                      | 7.4.3sb                   | 1.8|6.7.1|5.2.0.13398
+3.10-SNAPSHOT          | 3.1.11 (SpotBugs)                | 1.8.0                      | 7.4.3sb                   | 1.8|7.6|5.10.1.16922

--- a/README.md
+++ b/README.md
@@ -48,3 +48,4 @@ Findbugs Plugin version|Embedded SpotBugs/Findbugs version|Embedded Findsecbugs 
 3.8                    | 3.1.6 (SpotBugs)                 | 1.8.0                      | 7.4.3sb                   | 1.8|6.7.1|5.1.0.13090
 3.9                    | 3.1.8 (SpotBugs)                 | 1.8.0                      | 7.4.3sb                   | 1.8|6.7.1|5.2.0.13398
 3.10                   | 3.1.11 (SpotBugs)                | 1.8.0                      | 7.4.3sb                   | 1.8|7.6|5.10.1.16922
+3.11-SNAPSHOT          | 3.1.11 (SpotBugs)                | 1.8.0                      | 7.4.3sb                   | 1.8|7.6|5.10.1.16922

--- a/README.md
+++ b/README.md
@@ -47,4 +47,4 @@ Findbugs Plugin version|Embedded SpotBugs/Findbugs version|Embedded Findsecbugs 
 3.7                    | 3.1.2 (SpotBugs)                 | 1.7.1                      | 7.2.1sb                   | 1.8|6.7.1|5.1.0.13090
 3.8                    | 3.1.6 (SpotBugs)                 | 1.8.0                      | 7.4.3sb                   | 1.8|6.7.1|5.1.0.13090
 3.9                    | 3.1.8 (SpotBugs)                 | 1.8.0                      | 7.4.3sb                   | 1.8|6.7.1|5.2.0.13398
-3.10-SNAPSHOT          | 3.1.11 (SpotBugs)                | 1.8.0                      | 7.4.3sb                   | 1.8|7.6|5.10.1.16922
+3.10                   | 3.1.11 (SpotBugs)                | 1.8.0                      | 7.4.3sb                   | 1.8|7.6|5.10.1.16922

--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
   </scm>
 
   <properties>
-    <spotbugs.version>3.1.10</spotbugs.version>
+    <spotbugs.version>3.1.11</spotbugs.version>
     <jdk.min.version>1.8</jdk.min.version>
 
     <sonar.version>6.7.1</sonar.version>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>com.github.spotbugs</groupId>
   <artifactId>sonar-findbugs-plugin</artifactId>
-  <version>3.10.0-SNAPSHOT</version>
+  <version>3.10.0</version>
   <packaging>sonar-plugin</packaging>
 
   <name>SonarQube SpotBugs Plugin</name>

--- a/pom.xml
+++ b/pom.xml
@@ -50,8 +50,8 @@
     <spotbugs.version>3.1.11</spotbugs.version>
     <jdk.min.version>1.8</jdk.min.version>
 
-    <sonar.version>6.7.1</sonar.version>
-    <sonar-java.version>5.2.0.13398</sonar-java.version>
+    <sonar.version>7.6</sonar.version>
+    <sonar-java.version>5.10.1.16922</sonar-java.version>
     <fbcontrib.version>7.4.3.sb</fbcontrib.version>
     <findsecbugs.version>1.8.0</findsecbugs.version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>com.github.spotbugs</groupId>
   <artifactId>sonar-findbugs-plugin</artifactId>
-  <version>3.10.0</version>
+  <version>3.11.0-SNAPSHOT</version>
   <packaging>sonar-plugin</packaging>
 
   <name>SonarQube SpotBugs Plugin</name>

--- a/src/smoke-test/sonarqube-latest
+++ b/src/smoke-test/sonarqube-latest
@@ -1,7 +1,7 @@
 # Copied from https://github.com/SonarSource/docker-sonarqube/tree/master/7.1 under LGPL
 FROM openjdk:8
 
-ENV SONAR_VERSION=7.5 \
+ENV SONAR_VERSION=7.6 \
     SONARQUBE_HOME=/opt/sonarqube \
     # Database configuration
     # Defaults to using H2


### PR DESCRIPTION
This PR is to release sonar-findbugs 3.10 that supports SonarQube 7.6 *only*. This version does not support SonarQube 7.5 and older, see https://github.com/spotbugs/sonar-findbugs/pull/242#issuecomment-458971587 and https://github.com/gabrie-allaigre/sonar-gitlab-plugin/issues/213#issuecomment-459016381 for detail.
For LTS users, #243 will release sonar-findbugs 3.9.2.

This version also introduces the latest SpotBugs 3.1.11.