### PR TITLE
Specify the latest ASM version

### DIFF
--- a/src/main/java/org/sonar/plugins/findbugs/resource/DebugExtensionExtractor.java
+++ b/src/main/java/org/sonar/plugins/findbugs/resource/DebugExtensionExtractor.java
@@ -70,7 +70,7 @@ public class DebugExtensionExtractor {
         protected String debug;
 
         public AbstractClassVisitor() {
-            super(Opcodes.ASM5);
+            super(Opcodes.ASM7);
         }
 
         @Override

--- a/src/main/java/org/sonar/plugins/findbugs/resource/DebugExtensionExtractor.java
+++ b/src/main/java/org/sonar/plugins/findbugs/resource/DebugExtensionExtractor.java
@@ -19,9 +19,10 @@
  */
 package org.sonar.plugins.findbugs.resource;
 
+import edu.umd.cs.findbugs.classfile.engine.asm.FindBugsASM;
+
 import org.objectweb.asm.ClassReader;
 import org.objectweb.asm.ClassVisitor;
-import org.objectweb.asm.Opcodes;
 
 import javax.annotation.Nullable;
 import java.io.IOException;
@@ -70,7 +71,7 @@ public class DebugExtensionExtractor {
         protected String debug;
 
         public AbstractClassVisitor() {
-            super(Opcodes.ASM7);
+            super(FindBugsASM.ASM_VERSION);
         }
 
         @Override


### PR DESCRIPTION
This PR fixes #248. It is necessary to release 2.9.3 after we merge this fix.
It is also necessary to merge `release-for-lts` branch to `master`... this operation will be needless after SonarSource releases next LTS in near future (hopefully).