### PR TITLE
chore: stop depending on old configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,8 +34,6 @@ addons:
     organization: "spotbugs"
     token:
       secure: "TO179WgRUyyT2Yg92FpC1r746GaHDMZ7+rMiBqnXztoj5VWTn8U0+M9edyxQ+cKZtCznC4JoimdjBhne52vauWFuQsoczrxtnN7l4w+yemC799Mm5jEuPKoId1CQZkVc5g4hmmeV4Qg6H5K1or1gnl+MGGZ9tbUYOu2v+G2SyAA="
-    github_token:
-      secure: "F37JqWPpdlOl4oHvTAap9uw+MEqmIz60HiVKYmSpQHDZRb13VJ/pVO11GVhoUfiswOERIEe6Ot/diH/ZK7qhaJQtPJVdSHLyN5t9KSdLtP9wYHWINVR79q8nM7I0rOZ94XDbBsHEsFgC/IWAYizVavQpMw5AGt31qjTzac19BVQ="
 deploy:
   # deploy SNAPSHOT artifact onto Sonatype Nexus
   - provider: script


### PR DESCRIPTION
The `github_token` is deprecated, and it enforces SonarQube to use old feature that is removed from SonarCloud. Instead, we need to set GitHub token in the config page in the SonarCloud.

refs: https://docs.travis-ci.com/user/sonarcloud/