### PR TITLE
Issue #72 : Added config boolean to explicitly enable/disable Findbugs

### DIFF
--- a/src/main/java/org/sonar/plugins/findbugs/FindbugsConfiguration.java
+++ b/src/main/java/org/sonar/plugins/findbugs/FindbugsConfiguration.java
@@ -233,6 +233,10 @@ public class FindbugsConfiguration {
     return config.getBoolean(FindbugsConstants.ALLOW_UNCOMPILED_CODE).orElse(FindbugsConstants.ALLOW_UNCOMPILED_CODE_VALUE);
   }
 
+  public boolean isFindbugsEnabled() {
+    return config.getBoolean(FindbugsConstants.FINDBUGS_ENABLED_PROPERTY).orElse(FindbugsConstants.FINDBUGS_ENABLED_DEFAULT_VALUE);
+  }
+
   private File jsr305Lib;
   private File annotationsLib;
   private File fbContrib;
@@ -300,6 +304,15 @@ public class FindbugsConfiguration {
   public static List<PropertyDefinition> getPropertyDefinitions() {
     String subCategory = "FindBugs";
     return ImmutableList.of(
+      PropertyDefinition.builder(FindbugsConstants.FINDBUGS_ENABLED_PROPERTY)
+        .defaultValue(Boolean.toString(FindbugsConstants.FINDBUGS_ENABLED_DEFAULT_VALUE))
+        .type(PropertyType.BOOLEAN)
+        .category(CoreProperties.CATEGORY_JAVA)
+        .subCategory(subCategory)
+        .name("Enable FindBugs rules")
+        .description("Toggle whether external FindBugs analyzer should execute on this project.")
+        .onQualifiers(Qualifiers.PROJECT, Qualifiers.MODULE)
+        .build(),
       PropertyDefinition.builder(FindbugsConstants.EFFORT_PROPERTY)
         .defaultValue(FindbugsConstants.EFFORT_DEFAULT_VALUE)
         .category(CoreProperties.CATEGORY_JAVA)

--- a/src/main/java/org/sonar/plugins/findbugs/FindbugsConstants.java
+++ b/src/main/java/org/sonar/plugins/findbugs/FindbugsConstants.java
@@ -23,6 +23,9 @@ public final class FindbugsConstants {
 
   public static final String PLUGIN_NAME = "FindBugs";
 
+  public static final String FINDBUGS_ENABLED_PROPERTY = "sonar.findbugs.enabled";
+  public static final boolean FINDBUGS_ENABLED_DEFAULT_VALUE = true;
+
   public static final String EFFORT_PROPERTY = "sonar.findbugs.effort";
   public static final String EFFORT_DEFAULT_VALUE = "Default";
 

--- a/src/main/java/org/sonar/plugins/findbugs/FindbugsExecutor.java
+++ b/src/main/java/org/sonar/plugins/findbugs/FindbugsExecutor.java
@@ -100,6 +100,11 @@ public class FindbugsExecutor {
   }
 
   public Collection<ReportedBug> execute(boolean useFbContrib, boolean useFindSecBugs) {
+    if(!configuration.isFindbugsEnabled()) {
+      LOG.info("Findbugs analysis is explicitly disabled for this project, skipping execution.");
+      return new ArrayList<>();
+    }
+
     // We keep a handle on the current security manager because FB plays with it and we need to restore it before shutting down the executor
     // service
     SecurityManager currentSecurityManager = System.getSecurityManager();

--- a/src/test/java/org/sonar/plugins/findbugs/FindbugsExecutorTest.java
+++ b/src/test/java/org/sonar/plugins/findbugs/FindbugsExecutorTest.java
@@ -20,6 +20,7 @@
 package org.sonar.plugins.findbugs;
 
 import com.google.common.collect.Lists;
+import com.sun.org.apache.xpath.internal.operations.Bool;
 import org.apache.commons.io.FileUtils;
 import org.junit.Before;
 import org.junit.Rule;
@@ -35,6 +36,7 @@ import org.sonar.api.config.internal.MapSettings;
 
 import java.io.File;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Optional;
 
 import static org.fest.assertions.Assertions.assertThat;
@@ -62,6 +64,7 @@ public class FindbugsExecutorTest {
 
     configEmpty = mock(Configuration.class);
     when(configEmpty.getStringArray(any())).thenReturn(new String[0]);
+    when(configEmpty.getBoolean(FindbugsConstants.FINDBUGS_ENABLED_PROPERTY)).thenReturn(Optional.of(Boolean.TRUE));
     when(configEmpty.get(any())).thenReturn(Optional.of(""));
   }
 
@@ -99,6 +102,15 @@ public class FindbugsExecutorTest {
     assertThat(report).contains("priority=\"3\"");
   }
 
+  @Test
+  public void shouldSkipAnalysis() throws Exception {
+    FindbugsConfiguration conf = mockConf();
+    when(conf.isFindbugsEnabled()).thenReturn(false);
+
+    Collection<ReportedBug> issues = new FindbugsExecutor(conf, fsEmpty, configEmpty).execute();
+    assertThat(issues).isEmpty();
+  }
+
   @Test(expected = IllegalStateException.class)
   public void shouldTerminateAfterTimeout() throws Exception {
     FindbugsConfiguration conf = mockConf();
@@ -123,6 +135,7 @@ public class FindbugsExecutorTest {
     project.addFile(new File("test-resources/classes").getCanonicalPath());
     project.addSourceDir(new File("test-resources/src").getCanonicalPath());
     project.setCurrentWorkingDirectory(new File("test-resources"));
+    when(conf.isFindbugsEnabled()).thenReturn(true);
     when(conf.getFindbugsProject()).thenReturn(project);
     when(conf.saveIncludeConfigXml()).thenReturn(new File("test-resources/findbugs-include.xml"));
     when(conf.getExcludesFilters()).thenReturn(Lists.newArrayList(new File("test-resources/findbugs-exclude.xml"), new File("test-resources/fake-file.xml")));

--- a/src/test/java/org/sonar/plugins/findbugs/FindbugsPluginTest.java
+++ b/src/test/java/org/sonar/plugins/findbugs/FindbugsPluginTest.java
@@ -38,7 +38,7 @@ public class FindbugsPluginTest {
     FindbugsPlugin plugin = new FindbugsPlugin();
     plugin.define(ctx);
 
-    assertEquals("extension count", 23, ctx.getExtensions().size());
+    assertEquals("extension count", 24, ctx.getExtensions().size());
   }
 
 }


### PR DESCRIPTION
I added a simple boolean configuration to turn off Findbugs analysis.  It is not quite as elegant as inspecting the active profiles (as suggested in issue #72 ), but I couldn't easily find a way to access those from the plugin.

I manage some large enterprise deployments of SonarQube and we really need the ability to selectively disable Findbugs on certain projects.

If this PR should target a different branch like "release-for-lts" just let me know.  I'd like to incorporate it into the master for 7.x as well - should that be a distinct PR?