### PR TITLE
Reflect changes in lts branch, and release 3.11.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,3 +50,4 @@ Findbugs Plugin version|Embedded SpotBugs/Findbugs version|Embedded Findsecbugs 
 3.9.2                  | 3.1.11 (SpotBugs)                 | 1.8.0                      | 7.4.3sb                   | 1.8|6.7.1~7.5|5.2.0.13398
 3.10                   | 3.1.11 (SpotBugs)                | 1.8.0                      | 7.4.3sb                   | 1.8|7.6~|5.10.1.16922
 3.11.0                 | 3.1.12 (SpotBugs)                | 1.8.0                      | 7.4.3sb                   | 1.8|7.6~|5.10.1.16922
+3.12.0-SNAPSHOT        | 3.1.12 (SpotBugs)                | 1.8.0                      | 7.4.3sb                   | 1.8|7.6~|5.10.1.16922

--- a/README.md
+++ b/README.md
@@ -49,4 +49,4 @@ Findbugs Plugin version|Embedded SpotBugs/Findbugs version|Embedded Findsecbugs 
 3.9                    | 3.1.8 (SpotBugs)                 | 1.8.0                      | 7.4.3sb                   | 1.8|6.7.1|5.2.0.13398
 3.9.2                  | 3.1.11 (SpotBugs)                 | 1.8.0                      | 7.4.3sb                   | 1.8|6.7.1~7.5|5.2.0.13398
 3.10                   | 3.1.11 (SpotBugs)                | 1.8.0                      | 7.4.3sb                   | 1.8|7.6~|5.10.1.16922
-3.11-SNAPSHOT          | 3.1.12 (SpotBugs)                | 1.8.0                      | 7.4.3sb                   | 1.8|7.6~|5.10.1.16922
+3.11.0                 | 3.1.12 (SpotBugs)                | 1.8.0                      | 7.4.3sb                   | 1.8|7.6~|5.10.1.16922

--- a/README.md
+++ b/README.md
@@ -49,4 +49,4 @@ Findbugs Plugin version|Embedded SpotBugs/Findbugs version|Embedded Findsecbugs 
 3.9                    | 3.1.8 (SpotBugs)                 | 1.8.0                      | 7.4.3sb                   | 1.8|6.7.1|5.2.0.13398
 3.9.2                  | 3.1.11 (SpotBugs)                 | 1.8.0                      | 7.4.3sb                   | 1.8|6.7.1~7.5|5.2.0.13398
 3.10                   | 3.1.11 (SpotBugs)                | 1.8.0                      | 7.4.3sb                   | 1.8|7.6~|5.10.1.16922
-3.11-SNAPSHOT          | 3.1.11 (SpotBugs)                | 1.8.0                      | 7.4.3sb                   | 1.8|7.6~|5.10.1.16922
+3.11-SNAPSHOT          | 3.1.12 (SpotBugs)                | 1.8.0                      | 7.4.3sb                   | 1.8|7.6~|5.10.1.16922

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>com.github.spotbugs</groupId>
   <artifactId>sonar-findbugs-plugin</artifactId>
-  <version>3.11.0</version>
+  <version>3.12.0-SNAPSHOT</version>
   <packaging>sonar-plugin</packaging>
 
   <name>SonarQube SpotBugs Plugin</name>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>com.github.spotbugs</groupId>
   <artifactId>sonar-findbugs-plugin</artifactId>
-  <version>3.11.0-SNAPSHOT</version>
+  <version>3.11.0</version>
   <packaging>sonar-plugin</packaging>
 
   <name>SonarQube SpotBugs Plugin</name>

--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
   </scm>
 
   <properties>
-    <spotbugs.version>3.1.11</spotbugs.version>
+    <spotbugs.version>3.1.12</spotbugs.version>
     <jdk.min.version>1.8</jdk.min.version>
 
     <sonar.version>7.6</sonar.version>

--- a/src/main/java/org/sonar/plugins/findbugs/resource/DebugExtensionExtractor.java
+++ b/src/main/java/org/sonar/plugins/findbugs/resource/DebugExtensionExtractor.java
@@ -70,7 +70,7 @@ public class DebugExtensionExtractor {
         protected String debug;
 
         public AbstractClassVisitor() {
-            super(Opcodes.ASM5);
+            super(Opcodes.ASM7);
         }
 
         @Override

--- a/src/main/java/org/sonar/plugins/findbugs/resource/DebugExtensionExtractor.java
+++ b/src/main/java/org/sonar/plugins/findbugs/resource/DebugExtensionExtractor.java
@@ -19,9 +19,10 @@
  */
 package org.sonar.plugins.findbugs.resource;
 
+import edu.umd.cs.findbugs.classfile.engine.asm.FindBugsASM;
+
 import org.objectweb.asm.ClassReader;
 import org.objectweb.asm.ClassVisitor;
-import org.objectweb.asm.Opcodes;
 
 import javax.annotation.Nullable;
 import java.io.IOException;
@@ -70,7 +71,7 @@ public class DebugExtensionExtractor {
         protected String debug;
 
         public AbstractClassVisitor() {
-            super(Opcodes.ASM7);
+            super(FindBugsASM.ASM_VERSION);
         }
 
         @Override


### PR DESCRIPTION
These changes are applied to the branch for LTS support. We also need them even in `master` branch.

[Full Changelog](https://github.com/spotbugs/sonar-findbugs/compare/3.10.0...reflect-changes-in-lts-branch)

## Release Note
### Implemented enhancements:
* Bump up find-sec-bugs to 1.9.0
* Bump up spotbugs to 3.1.12

### Fixes:
* Incompatibility with sonar-java 5.12 #263
* Fails when analyzing Java 11 source code with nested class #248