### PR TITLE
Do not release in PR

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ jobs:
       script:
         - mvn org.jacoco:jacoco-maven-plugin:prepare-agent verify sonar:sonar -B -e -V -Dsonar.version=$SONAR_VERSION -Dsonar-java.version=$SONAR_JAVA_VERSION
     - stage: deploy
-      if: ( branch = master ) OR ( tag IS present )
+      if: ( type != pull_request ) AND ( ( branch = master ) OR ( tag IS present ) )
       script:
         - mvn deploy -B -P deploy -s .travis/settings.xml
 notifications:


### PR DESCRIPTION
Current setting runs `mvn deploy` in PR if the base branch is `master`.
By checking `type` we avoid this unsafe release.

According to [official doc](https://docs.travis-ci.com/user/conditions-v1), `branch` is the base branch name for PR. Then in PR for `master` branch, the `if` condition for deployment is fulfilled so unapproved change can be released to Sonatype Nexus Maven repository.