### PR TITLE
Release 3.11.1

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,20 @@
+name-template: '$NEXT_PATCH_VERSION'
+tag-template: '$NEXT_PATCH_VERSION'
+categories:
+  - title: '🚀 Implemented enhancements'
+    labels:
+      - 'enhancement'
+  - title: '🐛 Fixed bugs'
+    labels:
+      - 'bug'
+  - title: '🔧 Maintenance'
+    labels:
+      - 'chore'
+      - 'task'
+change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
+template: |
+  [Full Changelog](https://github.com/spotbugs/sonar-findbugs/compare/$PREVIOUS_TAG...$NEXT_PATCH_VERSION)
+
+  ## Release Note
+
+  $CHANGES

--- a/pom.xml
+++ b/pom.xml
@@ -138,7 +138,7 @@
     <dependency>
       <groupId>com.thoughtworks.xstream</groupId>
       <artifactId>xstream</artifactId>
-      <version>1.4.10</version>
+      <version>1.4.11</version>
       <exclusions>
         <!-- we use stax -->
         <exclusion>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>com.github.spotbugs</groupId>
   <artifactId>sonar-findbugs-plugin</artifactId>
-  <version>3.12.0-SNAPSHOT</version>
+  <version>3.11.1</version>
   <packaging>sonar-plugin</packaging>
 
   <name>SonarQube SpotBugs Plugin</name>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>com.github.spotbugs</groupId>
   <artifactId>sonar-findbugs-plugin</artifactId>
-  <version>3.11.1</version>
+  <version>3.11.2-SNAPSHOT</version>
   <packaging>sonar-plugin</packaging>
 
   <name>SonarQube SpotBugs Plugin</name>


### PR DESCRIPTION
This PR will handle:

1. Fix a vulnerability `CVE-2019-10173 `, 
2. Introduce CI tool that helps making release note, and
3. Release v3.11.1 to Maven Central.