### PR TITLE
chore: introduce release drafter

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,20 @@
+name-template: '$NEXT_PATCH_VERSION'
+tag-template: '$NEXT_PATCH_VERSION'
+categories:
+  - title: '🚀 Implemented enhancements'
+    labels:
+      - 'enhancement'
+  - title: '🐛 Fixed bugs'
+    labels:
+      - 'bug'
+  - title: '🔧 Maintenance'
+    labels:
+      - 'chore'
+      - 'task'
+change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
+template: |
+  [Full Changelog](https://github.com/spotbugs/sonar-findbugs/compare/$PREVIOUS_TAG...$NEXT_PATCH_VERSION)
+
+  ## Release Note
+
+  $CHANGES

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,15 @@
+name: Release Drafter
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  update_release_draft:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: release-drafter/release-drafter@v5
+        with:
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
To be honest, I am not good at [this GitHub App](https://github.com/toolmantim/release-drafter#readme), but I hope it matches with our workflow that needs manual tagging.

Another idea is introducing semantic-release, that I much prefer, but it enforces all contributors to follow [the conventional commit comment](https://www.conventionalcommits.org/en/v1.0.0-beta.4/) that could be troublesome for you.