### PR TITLE
Issue #276 : Added config boolean to explicitly enable/disable Findbugs Analyzer

### DIFF
--- a/src/main/java/org/sonar/plugins/findbugs/FindbugsConfiguration.java
+++ b/src/main/java/org/sonar/plugins/findbugs/FindbugsConfiguration.java
@@ -262,6 +262,10 @@ public class FindbugsConfiguration implements Startable {
     return config.getBoolean(FindbugsConstants.ALLOW_UNCOMPILED_CODE).orElse(FindbugsConstants.ALLOW_UNCOMPILED_CODE_VALUE);
   }
 
+  public boolean isFindbugsEnabled() {
+    return config.getBoolean(FindbugsConstants.FINDBUGS_ENABLED_PROPERTY).orElse(FindbugsConstants.FINDBUGS_ENABLED_DEFAULT_VALUE);
+  }
+
   private File jsr305Lib;
   private File annotationsLib;
   private File fbContrib;
@@ -335,6 +339,15 @@ public class FindbugsConfiguration implements Startable {
   public static List<PropertyDefinition> getPropertyDefinitions() {
     String subCategory = "FindBugs";
     return ImmutableList.of(
+      PropertyDefinition.builder(FindbugsConstants.FINDBUGS_ENABLED_PROPERTY)
+        .defaultValue(Boolean.toString(FindbugsConstants.FINDBUGS_ENABLED_DEFAULT_VALUE))
+        .type(PropertyType.BOOLEAN)
+        .category(CoreProperties.CATEGORY_JAVA)
+        .subCategory(subCategory)
+        .name("Enable FindBugs rules")
+        .description("Toggle whether external FindBugs analyzer should execute on this project.")
+        .onQualifiers(Qualifiers.PROJECT, Qualifiers.MODULE)
+        .build(),
       PropertyDefinition.builder(FindbugsConstants.EFFORT_PROPERTY)
         .defaultValue(FindbugsConstants.EFFORT_DEFAULT_VALUE)
         .category(CoreProperties.CATEGORY_JAVA)

--- a/src/main/java/org/sonar/plugins/findbugs/FindbugsConstants.java
+++ b/src/main/java/org/sonar/plugins/findbugs/FindbugsConstants.java
@@ -23,6 +23,9 @@ public final class FindbugsConstants {
 
   public static final String PLUGIN_NAME = "FindBugs";
 
+  public static final String FINDBUGS_ENABLED_PROPERTY = "sonar.findbugs.enabled";
+  public static final boolean FINDBUGS_ENABLED_DEFAULT_VALUE = true;
+
   public static final String EFFORT_PROPERTY = "sonar.findbugs.effort";
   public static final String EFFORT_DEFAULT_VALUE = "Default";
 

--- a/src/main/java/org/sonar/plugins/findbugs/FindbugsExecutor.java
+++ b/src/main/java/org/sonar/plugins/findbugs/FindbugsExecutor.java
@@ -100,6 +100,11 @@ public class FindbugsExecutor {
   }
 
   public Collection<ReportedBug> execute(boolean useFbContrib, boolean useFindSecBugs) {
+    if(!configuration.isFindbugsEnabled()) {
+      LOG.info("Findbugs analysis is explicitly disabled for this project, skipping execution.");
+      return new ArrayList<>();
+    }
+
     // We keep a handle on the current security manager because FB plays with it and we need to restore it before shutting down the executor
     // service
     SecurityManager currentSecurityManager = System.getSecurityManager();

--- a/src/test/java/org/sonar/plugins/findbugs/FindbugsPluginTest.java
+++ b/src/test/java/org/sonar/plugins/findbugs/FindbugsPluginTest.java
@@ -37,7 +37,7 @@ public class FindbugsPluginTest {
     FindbugsPlugin plugin = new FindbugsPlugin();
     plugin.define(ctx);
 
-    assertEquals("extension count", 21, ctx.getExtensions().size());
+    assertEquals("extension count", 22, ctx.getExtensions().size());
   }
 
 }


### PR DESCRIPTION
This is a re-submission of PR #258 to address Issue #276 

Given the discussion on the issue comments, there seems to be use cases where an explicit flag is preferred over implicit rule detection on the profile.  So I decided to resubmit the same changes since it addresses both my own use case and some of the broader community use cases.