### PR TITLE
Do not add the classes of directories listed on the classpath to the classFilesToAnalyze

### DIFF
--- a/src/main/java/org/sonar/plugins/findbugs/FindbugsConfiguration.java
+++ b/src/main/java/org/sonar/plugins/findbugs/FindbugsConfiguration.java
@@ -90,11 +90,6 @@ public class FindbugsConfiguration implements Startable {
     List<File> classFilesToAnalyze = new ArrayList<>(javaResourceLocator.classFilesToAnalyze());
 
     for (File file : javaResourceLocator.classpath()) {
-      //Will capture additional classes including precompiled JSP
-      if(file.isDirectory()) { // will include "/target/classes" and other non-standard folders
-        classFilesToAnalyze.addAll(scanForAdditionalClasses(file));
-      }
-
       //Auxiliary dependencies
       findbugsProject.addAuxClasspathEntry(file.getCanonicalPath());
     }


### PR DESCRIPTION
Seen in a Gradle multi-project build using the Java Library plugin. This plugin puts the classes output directory on the classpath instead of the Jar file which the Java Plugin does. This resulted in longer analysation times as classes of project dependencies would be scanned multiple times.

This fixes #275 