### PR TITLE
Checkout the repo before the deployment

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,6 +54,13 @@ jobs:
     needs: build
     if: github.event_name == 'release' || ( github.event_name == 'push' && github.ref == 'refs/heads/master' )
     steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Set up JDK 11
+        uses: actions/setup-java@v1
+        with:
+          java-version: 11
       - name: Deploy artifacts to Maven Central
         run: |
           mvn clean deploy -B -e -P deploy -s .github/settings.xml -DskipTests


### PR DESCRIPTION
The [build in GitHub Actions](https://github.com/spotbugs/sonar-findbugs/runs/1647267180) is failed, because I simply forgot checking out the Git repo... 😩

I'm sorry, here is fix for the problem. refs #350