### PR TITLE
Run SonarQube in pull_request_target

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,6 @@ jobs:
           # minimal support version
           - SONAR_VERSION: 7.6
             SONAR_JAVA_VERSION: 5.10.1.16922
-            USE_SONAR: true
           # latest LTS version
           - SONAR_VERSION: 7.9
             SONAR_JAVA_VERSION: 5.13.1.18282
@@ -39,7 +38,7 @@ jobs:
           distribution: adopt
       - name: Build
         run: |
-          mvn org.jacoco:jacoco-maven-plugin:prepare-agent verify ${USE_SONAR:+sonar:sonar} -B -e -V \
+          mvn org.jacoco:jacoco-maven-plugin:prepare-agent verify -B -e -V \
             -Dsonar.version=${{ matrix.SONAR_VERSION }} \
             -Dsonar-java.version=${{ matrix.SONAR_JAVA_VERSION }} \
             -Dsonar.projectKey=com.github.spotbugs:sonar-findbugs-plugin \
@@ -49,7 +48,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_LOGIN: ${{ secrets.SONAR_LOGIN }}
-          USE_SONAR: ${{ matrix.USE_SONAR }}
           CI: true
   deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,17 +38,7 @@ jobs:
           distribution: temurin
       - name: Build
         run: |
-          mvn org.jacoco:jacoco-maven-plugin:prepare-agent verify -B -e -V \
-            -Dsonar.version=${{ matrix.SONAR_VERSION }} \
-            -Dsonar-java.version=${{ matrix.SONAR_JAVA_VERSION }} \
-            -Dsonar.projectKey=com.github.spotbugs:sonar-findbugs-plugin \
-            -Dsonar.organization=spotbugs \
-            -Dsonar.host.url=https://sonarcloud.io \
-            -Dsonar.login=$SONAR_LOGIN
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SONAR_LOGIN: ${{ secrets.SONAR_LOGIN }}
-          CI: true
+          mvn verify -B -e -V
   deploy:
     runs-on: ubuntu-latest
     needs: build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,7 +35,7 @@ jobs:
         uses: actions/setup-java@v2
         with:
           java-version: 11
-          distribution: adopt
+          distribution: temurin
       - name: Build
         run: |
           mvn org.jacoco:jacoco-maven-plugin:prepare-agent verify -B -e -V \
@@ -61,7 +61,7 @@ jobs:
         uses: actions/setup-java@v2
         with:
           java-version: 11
-          distribution: adopt
+          distribution: temurin
           server-id: ossrh
           server-username: OSSRH_JIRA_USERNAME
           server-password: OSSRH_JIRA_PASSWORD

--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -1,0 +1,37 @@
+on:
+  push:
+    branches:
+      - master
+  pull_request_target:
+    branches:
+      - master
+
+jobs:
+  build:
+    runs-on: ubuntu-20.04
+    env:
+      # minimal support version
+      SONAR_VERSION: 7.6
+      SONAR_JAVA_VERSION: 5.10.1.16922
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Set up JDK 11
+        uses: actions/setup-java@v2
+        with:
+          java-version: 11
+          distribution: temurin
+      - name: Build
+        run: |
+          mvn org.jacoco:jacoco-maven-plugin:prepare-agent verify sonar:sonar -B -e -V \
+            -Dsonar.version=${{ env.SONAR_VERSION }} \
+            -Dsonar-java.version=${{ env.SONAR_JAVA_VERSION }} \
+            -Dsonar.projectKey=com.github.spotbugs:sonar-findbugs-plugin \
+            -Dsonar.organization=spotbugs \
+            -Dsonar.host.url=https://sonarcloud.io \
+            -Dsonar.login=$SONAR_LOGIN
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SONAR_LOGIN: ${{ secrets.SONAR_LOGIN }}
+          CI: true

--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -6,6 +6,15 @@ on:
     branches:
       - master
 
+# set necessary permissions for SQ's GitHub integration
+# https://docs.sonarqube.org/latest/analysis/github-integration/#header-2
+permissions:
+  checks: write
+  contents: read
+  metadata: read
+  pull-requests: write
+  statuses: read
+
 jobs:
   build:
     runs-on: ubuntu-20.04


### PR DESCRIPTION
This PR makes SonarQube running properly even in the PR from forked repos.
refs https://github.blog/2020-08-03-github-actions-improvements-for-fork-and-pull-request-workflows/

Also replace the AdoptOpenJDK with Adoptium, because [AdoptOpenJDK will not be updated](https://blog.adoptopenjdk.net/2021/08/goodbye-adoptopenjdk-hello-adoptium/) soon.