### PR TITLE
Resolve several problems around SonarQube analysis

### DIFF
--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -43,9 +43,10 @@ jobs:
             -Dsonar.organization=spotbugs \
             -Dsonar.host.url=https://sonarcloud.io \
             -Dsonar.login=$SONAR_LOGIN \
-            ${PR_NUMBER:+ -Dsonar.pullrequest.key=$PR_NUMBER -Dsonar.pullrequest.branch=${{ github.event.pull_request.head.ref }} }
+            ${PR_NUMBER:+ -Dsonar.pullrequest.key=$PR_NUMBER -Dsonar.pullrequest.branch=$PR_BRANCH }
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_LOGIN: ${{ secrets.SONAR_LOGIN }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_BRANCH: ${{ github.event.pull_request.head.ref }}
           CI: true

--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -28,7 +28,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
-          ref: ${{ github.event.pull_request.head.sha || github.ref }}
+          ref: ${{ github.event.pull_request.head.ref || github.ref }}
       - name: Set up JDK 11
         uses: actions/setup-java@v2
         with:
@@ -43,7 +43,7 @@ jobs:
             -Dsonar.organization=spotbugs \
             -Dsonar.host.url=https://sonarcloud.io \
             -Dsonar.login=$SONAR_LOGIN \
-            ${PR_NUMBER:+ -Dsonar.pullrequest.key=$PR_NUMBER }
+            ${PR_NUMBER:+ -Dsonar.pullrequest.key=$PR_NUMBER -Dsonar.pullrequest.branch=${{ github.event.pull_request.head.ref }} }
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_LOGIN: ${{ secrets.SONAR_LOGIN }}

--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -28,7 +28,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          ref: ${{ github.event.pull_request.head.sha || github.ref }}
       - name: Set up JDK 11
         uses: actions/setup-java@v2
         with:

--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -5,6 +5,9 @@ on:
   pull_request_target:
     branches:
       - master
+  release:
+    types:
+      - created
 
 # set necessary permissions for SQ's GitHub integration
 # https://docs.sonarqube.org/latest/analysis/github-integration/#header-2

--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -25,6 +25,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
       - name: Set up JDK 11
         uses: actions/setup-java@v2
         with:
@@ -38,8 +39,10 @@ jobs:
             -Dsonar.projectKey=com.github.spotbugs:sonar-findbugs-plugin \
             -Dsonar.organization=spotbugs \
             -Dsonar.host.url=https://sonarcloud.io \
-            -Dsonar.login=$SONAR_LOGIN
+            -Dsonar.login=$SONAR_LOGIN \
+            ${PR_NUMBER:+ -Dsonar.pullrequest.key=$PR_NUMBER }
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_LOGIN: ${{ secrets.SONAR_LOGIN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
           CI: true


### PR DESCRIPTION
Follow up for #380. That change made SQ running in PR from the forked repo, but we have two problems:

1. [Analysis runs on the BASE](https://github.com/spotbugs/sonar-findbugs/pull/382/checks#step:2:489) but it should use HEAD
2. Analysis result wasn't reported on its source PR like #382

Also, I found that SQ didn't run on a tag but it's necessary to [request a release at SQ forum](https://community.sonarsource.com/t/new-release-sonar-findbugs-4-0-4/48718). This PR will tackle these three problems.