### PR TITLE
Issue #387 Add deprecated jsp rule key

### DIFF
--- a/src/main/java/org/sonar/plugins/findbugs/FindbugsProfileImporter.java
+++ b/src/main/java/org/sonar/plugins/findbugs/FindbugsProfileImporter.java
@@ -124,11 +124,14 @@ public class FindbugsProfileImporter {
   }
   
   private void activateRule(NewBuiltInQualityProfile profile, Rule rule, @Nullable String severity) {
-    NewBuiltInActiveRule r = profile.activateRule(rule.getRepositoryKey(), rule.getKey());
-    if (severity == null) {
-      r.overrideSeverity(getSeverityFromPriority(rule.getSeverity()));
-    } else {
-      r.overrideSeverity(severity);
+    // Trying to activate a disabled rule in a profile causes the SQ server to crash at startup
+    if (rule.isEnabled()) {
+      NewBuiltInActiveRule r = profile.activateRule(rule.getRepositoryKey(), rule.getKey());
+      if (severity == null) {
+        r.overrideSeverity(getSeverityFromPriority(rule.getSeverity()));
+      } else {
+        r.overrideSeverity(severity);
+      }
     }
   }
 

--- a/src/main/java/org/sonar/plugins/findbugs/rules/FindSecurityBugsJspRulesDefinition.java
+++ b/src/main/java/org/sonar/plugins/findbugs/rules/FindSecurityBugsJspRulesDefinition.java
@@ -41,6 +41,23 @@ public class FindSecurityBugsJspRulesDefinition implements RulesDefinition {
 
         RulesDefinitionXmlLoader ruleLoaderJsp = new RulesDefinitionXmlLoader();
         ruleLoaderJsp.load(repositoryJsp, FindSecurityBugsRulesDefinition.class.getResourceAsStream("/org/sonar/plugins/findbugs/rules-jsp.xml"), "UTF-8");
+        
+        addDeprecatedRuleKeys(repositoryJsp);
+        
         repositoryJsp.done();
+    }
+
+    public void addDeprecatedRuleKeys(NewRepository repositoryJsp) {
+        String[] rulesMovedFromFindSecurityBugs = new String[] {
+            "XSS_JSP_PRINT",
+            "XSS_REQUEST_PARAMETER_TO_JSP_WRITER"
+        };
+      
+        for (String key : rulesMovedFromFindSecurityBugs) {
+            NewRule rule = repositoryJsp.rule(key);
+            if (rule != null) {
+                rule.addDeprecatedRuleKey(FindSecurityBugsRulesDefinition.REPOSITORY_KEY, key);
+            }
+        }
     }
 }


### PR DESCRIPTION
Between version 3.3 and 3.4 of the plugin rules XSS_JSP_PRINT and XSS_REQUEST_PARAMETER_TO_JSP_WRITER have been moved from the Java findsecbugs repository to the JSP findsecbugs-jsp repository.

When a rule key is modified the plugin should apparently declare it's "deprecated key(s)" to let SonarQube know, see: https://javadocs.sonarsource.org/7.1/apidocs/org/sonar/api/server/rule/RulesDefinition.Rule.html#deprecatedRuleKeys--

The database was left in an apparently inconsistent state for SQ installations where the plugin had been upgraded from <= 3.3 to >= 3.4
Then when the API used to load profiles was changed in https://github.com/spotbugs/sonar-findbugs/pull/369 (to make the plugin compatible with SQ 9) the server crashed on startup with error: `BadRequestException: java rule findsecbugs:XSS_JSP_PRINT cannot be activated on jsp profile FindBugs Security JSP`

This PR adds the "deprecated keys" (i.e. the old rules ID) for these two rules and prevent the plugin from trying to activate a removed rule into a profile.