### PR TITLE
ci: checkout the merge commit for PR_target event

### DIFF
--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -25,10 +25,17 @@ jobs:
       SONAR_VERSION: 7.6
       SONAR_JAVA_VERSION: 5.10.1.16922
     steps:
+      - name: Decide the ref to check out
+        uses: haya14busa/action-cond@v1
+        id: condval
+        with:
+          cond: ${{ github.event_name == 'pull_request_target' }}
+          if_true: refs/pull/${{ github.event.pull_request.number }}/merge
+          if_false: ${{ github.ref }}
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
-          ref: ${{ github.event.pull_request.head.ref || github.ref }}
+          ref: ${{ steps.condval.outputs.value }}
       - name: Set up JDK 11
         uses: actions/setup-java@v2
         with:


### PR DESCRIPTION
Currently the build in PR is broken, see [this workflow run for example](https://github.com/spotbugs/sonar-findbugs/runs/3948483294?check_suite_focus=true#step:2:498).

>   Error: A branch or tag with the name 'add-deprecated-jsp-rule-key' could not be found

It is because `github.event.pull_request.head.ref` points the branch name, which does not exist in this repo. It exists in another forked repository.

To solve this issue, we can checkout the branch `refs/pull/${{ github.event.pull_request.number }}/merge` [which is the default branch to checkout for `pull_request` event](https://docs.github.com/en/actions/learn-github-actions/events-that-trigger-workflows#pull_request).