### PR TITLE
ci: skip the SonarQube analysis on forked repos

### DIFF
--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -19,6 +19,8 @@ permissions:
 
 jobs:
   build:
+    # Forked repos do not have access to the Sonar account
+    if: github.repository == 'spotbugs/sonar-findbugs'
     runs-on: ubuntu-20.04
     env:
       # minimal support version


### PR DESCRIPTION
Currently the build tries to run a SonarQube analysis but this fails when running on a forked repo, because it does not have access to the account secrets.