### PR TITLE
ci: add missing param to cache dependency in sub project

### DIFF
--- a/.github/workflows/sonar-update-center.yml
+++ b/.github/workflows/sonar-update-center.yml
@@ -32,6 +32,7 @@ jobs:
         with:
           node-version: '${{ steps.nvm.outputs.NVMRC }}'
           cache: npm
+          cache-dependency-path: .github/actions/sonar-update-center/package-lock.json
       - run: |
           npm ci
           npm run all


### PR DESCRIPTION
Add a [missing parameter to support sub project](https://github.com/actions/setup-node/tree/360ab8b75b056fc18d368ee27a78d34e29c0b2d9#caching-packages-dependencies), which makes #405 and other builds failed.

Note that this workflow file defines a workflow triggered by a `pull_request_target` event, so we need to merge the change first to fix the problem. In other words, the related GitHub Check will fail even in this PR. It is because `pull_request_target` always use the workflow definition in the default branch.