### PR TITLE
ci: skip the deploy when running on a forked repo

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,7 +42,8 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     needs: build
-    if: github.event_name == 'release' || ( github.event_name == 'push' && github.ref == 'refs/heads/master' )
+    # Forked repos do not have the secrets to deploy so this would fail
+    if: ( github.event_name == 'release' || ( github.event_name == 'push' && github.ref == 'refs/heads/master' )) && github.repository == 'spotbugs/sonar-findbugs'
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,6 +36,7 @@ jobs:
         with:
           java-version: 11
           distribution: temurin
+          cache: 'maven'
       - name: Build
         run: |
           mvn verify -B -e -V
@@ -53,6 +54,7 @@ jobs:
         with:
           java-version: 11
           distribution: temurin
+          cache: 'maven'
           server-id: ossrh
           server-username: OSSRH_JIRA_USERNAME
           server-password: OSSRH_JIRA_PASSWORD


### PR DESCRIPTION
* Currently the deploy tries to run on forked repos and fails because it does not have the secrets
* Cache the maven dependencies to speed up the build