### PR TITLE
Revert to SpotBugs 4.5.2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -86,7 +86,7 @@ jobs:
         uses: ./.github/actions/sonar-update-center
         with:
           prop-file: findbugs.properties
-          description: Use SpotBugs 4.5.3, sb-contrib 7.4.7, and findsecbugs 1.11.0
+          description: Use SpotBugs 4.5.2, sb-contrib 7.4.7, and findsecbugs 1.11.0
           minimal-supported-sq-version: 8.9
           latest-supported-sq-version: LATEST
           changelog-url: https://github.com/spotbugs/sonar-findbugs/releases/tag/${{ github.event.release.tag_name }}

--- a/README.md
+++ b/README.md
@@ -46,4 +46,4 @@ Findbugs Plugin version|Embedded SpotBugs/Findbugs version|Embedded Findsecbugs 
 4.0.3                  | 4.2.0 (SpotBugs)                 | 1.11.0                     | 7.4.7 (sb-contrib)        | 1.8|7.9-8.9|5.10.1.16922
 4.0.4                  | 4.4.0 (SpotBugs)                 | 1.11.0                     | 7.4.7 (sb-contrib)        | 1.8|7.9~|5.10.1.16922
 4.0.5                  | 4.5.0 (SpotBugs)                 | 1.11.0                     | 7.4.7 (sb-contrib)        | 1.8|7.9~|5.10.1.16922
-4.0.6-SNAPSHOT         | 4.5.3 (SpotBugs)                 | 1.11.0                     | 7.4.7 (sb-contrib)        | 1.8|7.9~|5.10.1.16922
+4.0.6-SNAPSHOT         | 4.5.2 (SpotBugs)                 | 1.11.0                     | 7.4.7 (sb-contrib)        | 1.8|7.9~|5.10.1.16922

--- a/generate_profiles/BuildXmlFiles.groovy
+++ b/generate_profiles/BuildXmlFiles.groovy
@@ -7,13 +7,13 @@ import groovy.json.JsonSlurper;
 
 @Grapes([
 
-    @Grab(group='com.github.spotbugs', module='spotbugs', version='4.5.3'),
+    @Grab(group='com.github.spotbugs', module='spotbugs', version='4.5.2'),
     @Grab(group='com.mebigfatguy.sb-contrib', module='sb-contrib', version='7.4.7'),
     @Grab(group='com.h3xstream.findsecbugs' , module='findsecbugs-plugin', version='1.11.0')]
 )
 
 
-FB = new Plugin(groupId: 'com.github.spotbugs', artifactId: 'spotbugs', version: '4.5.3')
+FB = new Plugin(groupId: 'com.github.spotbugs', artifactId: 'spotbugs', version: '4.5.2')
 CONTRIB = new Plugin(groupId: 'com.mebigfatguy.sb-contrib', artifactId: 'sb-contrib', version: '7.4.7')
 FSB = new Plugin(groupId: 'com.h3xstream.findsecbugs', artifactId: 'findsecbugs-plugin', version: '1.11.0')
 

--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
       Also need to update profiles, see ./generate_profiles/README.md for detail.
       Update the version table and the rules count badge in README.md
     -->
-    <spotbugs.version>4.5.3</spotbugs.version>
+    <spotbugs.version>4.5.2</spotbugs.version>
     <sbcontrib.version>7.4.7</sbcontrib.version>
     <findsecbugs.version>1.11.0</findsecbugs.version>
 


### PR DESCRIPTION
SpotBugs 4.5.3 surfaced a bug in FindSecBugs, revert to 4.5.2 until a new version with the fix is release, see: https://github.com/find-sec-bugs/find-sec-bugs/issues/668