### PR TITLE
test: IT reproducing issue #516 and UT for languages

### DIFF
--- a/src/test/java/org/sonar/plugins/findbugs/profiles/FindbugsContribProfileTest.java
+++ b/src/test/java/org/sonar/plugins/findbugs/profiles/FindbugsContribProfileTest.java
@@ -31,5 +31,7 @@ class FindbugsContribProfileTest {
     assertThat(profile.rules().stream().filter(r -> r.repoKey().equals(FindbugsRulesDefinition.REPOSITORY_KEY)).count()).isEqualTo(FindbugsRulesDefinition.RULE_COUNT);
     assertThat(profile.rules().stream().filter(r -> r.repoKey().equals(FbContribRulesDefinition.REPOSITORY_KEY)).count()).isEqualTo(FbContribRulesDefinition.RULE_COUNT);
     assertThat(logTester.getLogs(LoggerLevel.ERROR)).isNull();
+
+    FindbugsProfileTest.assertHasOnlyRulesForLanguage(profile.rules(), Java.KEY);
   }
 }

--- a/src/test/java/org/sonar/plugins/findbugs/profiles/FindbugsProfileTest.java
+++ b/src/test/java/org/sonar/plugins/findbugs/profiles/FindbugsProfileTest.java
@@ -21,17 +21,26 @@ package org.sonar.plugins.findbugs.profiles;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
+import org.sonar.api.server.profile.BuiltInQualityProfilesDefinition.BuiltInActiveRule;
 import org.sonar.api.server.profile.BuiltInQualityProfilesDefinition.BuiltInQualityProfile;
 import org.sonar.api.server.profile.BuiltInQualityProfilesDefinition.Context;
 import org.sonar.api.utils.log.LogTester;
 import org.sonar.api.utils.log.LoggerLevel;
 import org.sonar.plugins.findbugs.FindbugsProfileImporter;
+import org.sonar.plugins.findbugs.language.Jsp;
+import org.sonar.plugins.findbugs.language.scala.Scala;
 import org.sonar.plugins.findbugs.rule.FakeRuleFinder;
+import org.sonar.plugins.findbugs.rules.FbContribRulesDefinition;
+import org.sonar.plugins.findbugs.rules.FindSecurityBugsJspRulesDefinition;
+import org.sonar.plugins.findbugs.rules.FindSecurityBugsRulesDefinition;
+import org.sonar.plugins.findbugs.rules.FindSecurityBugsScalaRulesDefinition;
 import org.sonar.plugins.findbugs.rules.FindbugsRulesDefinition;
 import org.sonar.plugins.findbugs.util.JupiterLogTester;
 import org.sonar.plugins.java.Java;
 
 import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
 
 class FindbugsProfileTest {
 
@@ -49,5 +58,30 @@ class FindbugsProfileTest {
     assertThat(profile.rules()).hasSize(FindbugsRulesDefinition.RULE_COUNT);
     assertThat(profile.rules().stream().filter(r -> r.repoKey().equals(FindbugsRulesDefinition.REPOSITORY_KEY)).count()).isEqualTo(FindbugsRulesDefinition.RULE_COUNT);
     assertThat(logTester.getLogs(LoggerLevel.ERROR)).isNull();
+
+    FindbugsProfileTest.assertHasOnlyRulesForLanguage(profile.rules(), Java.KEY);
+  }
+  
+  public static void assertHasOnlyRulesForLanguage(List<BuiltInActiveRule> rules, String language) {
+    switch (language) {
+    case Java.KEY:
+      assertThat(rules.stream().filter(r -> r.repoKey().equals(FindSecurityBugsJspRulesDefinition.REPOSITORY_KEY)).count()).withFailMessage("Java profiles must only contain Java rules").isZero();
+      assertThat(rules.stream().filter(r -> r.repoKey().equals(FindSecurityBugsScalaRulesDefinition.REPOSITORY_KEY)).count()).withFailMessage("Java profiles must only contain Java rules").isZero();
+      break;
+    case Jsp.KEY:
+      assertThat(rules.stream().filter(r -> r.repoKey().equals(FindbugsRulesDefinition.REPOSITORY_KEY)).count()).withFailMessage("JSP profiles must only contain JSP rules").isZero();
+      assertThat(rules.stream().filter(r -> r.repoKey().equals(FbContribRulesDefinition.REPOSITORY_KEY)).count()).withFailMessage("JSP profiles must only contain JSP rules").isZero();
+      assertThat(rules.stream().filter(r -> r.repoKey().equals(FindSecurityBugsRulesDefinition.REPOSITORY_KEY)).count()).withFailMessage("JSP profiles must only contain JSP rules").isZero();
+      assertThat(rules.stream().filter(r -> r.repoKey().equals(FindSecurityBugsScalaRulesDefinition.REPOSITORY_KEY)).count()).withFailMessage("JSP profiles must only contain JSP rules").isZero();
+      break;
+    case Scala.KEY:
+      assertThat(rules.stream().filter(r -> r.repoKey().equals(FindbugsRulesDefinition.REPOSITORY_KEY)).count()).withFailMessage("Scala profiles must only contain Scala rules").isZero();
+      assertThat(rules.stream().filter(r -> r.repoKey().equals(FbContribRulesDefinition.REPOSITORY_KEY)).count()).withFailMessage("Scala profiles must only contain Scala rules").isZero();
+      assertThat(rules.stream().filter(r -> r.repoKey().equals(FindSecurityBugsRulesDefinition.REPOSITORY_KEY)).count()).withFailMessage("Scala profiles must only contain Scala rules").isZero();
+      assertThat(rules.stream().filter(r -> r.repoKey().equals(FindSecurityBugsJspRulesDefinition.REPOSITORY_KEY)).count()).withFailMessage("Scala profiles must only contain Scala rules").isZero();
+      break;
+    default:
+      throw new IllegalArgumentException("Unexpected language: " + language);
+    }
   }
 }

--- a/src/test/java/org/sonar/plugins/findbugs/profiles/FindbugsScalaProfileTest.java
+++ b/src/test/java/org/sonar/plugins/findbugs/profiles/FindbugsScalaProfileTest.java
@@ -47,5 +47,7 @@ class FindbugsScalaProfileTest {
     assertThat(profile.rules()).hasSize(FindSecurityBugsScalaRulesDefinition.RULE_COUNT);
     assertThat(profile.rules().stream().filter(r -> r.repoKey().equals(FindSecurityBugsScalaRulesDefinition.REPOSITORY_KEY)).count()).isEqualTo(FindSecurityBugsScalaRulesDefinition.RULE_COUNT);
     assertThat(logTester.getLogs(LoggerLevel.ERROR)).isNull();
+
+    FindbugsProfileTest.assertHasOnlyRulesForLanguage(profile.rules(), Scala.KEY);
   }
 }

--- a/src/test/java/org/sonar/plugins/findbugs/profiles/FindbugsSecurityAuditProfileTest.java
+++ b/src/test/java/org/sonar/plugins/findbugs/profiles/FindbugsSecurityAuditProfileTest.java
@@ -54,5 +54,7 @@ class FindbugsSecurityAuditProfileTest {
     assertThat(profile.rules().stream().filter(r -> r.repoKey().equals(FindbugsRulesDefinition.REPOSITORY_KEY)).count()).isEqualTo(8);
     assertThat(profile.rules().stream().filter(r -> r.repoKey().equals(FindSecurityBugsRulesDefinition.REPOSITORY_KEY)).count())
     .isEqualTo(FindSecurityBugsRulesDefinition.RULE_COUNT);
+
+    FindbugsProfileTest.assertHasOnlyRulesForLanguage(profile.rules(), Java.KEY);
   }
 }

--- a/src/test/java/org/sonar/plugins/findbugs/profiles/FindbugsSecurityJspProfileTest.java
+++ b/src/test/java/org/sonar/plugins/findbugs/profiles/FindbugsSecurityJspProfileTest.java
@@ -53,6 +53,8 @@ class FindbugsSecurityJspProfileTest {
     assertThat(logTester.getLogs(LoggerLevel.WARN)).isNull();
     assertThat(profile.rules().stream().filter(r -> r.repoKey().equals(FindSecurityBugsJspRulesDefinition.REPOSITORY_KEY)).count()).isEqualTo(6);
     assertThat(profile.rules().stream().filter(r -> r.repoKey().equals(FindbugsRulesDefinition.REPOSITORY_KEY)).count()).isZero();
+
+    FindbugsProfileTest.assertHasOnlyRulesForLanguage(profile.rules(), Jsp.KEY);
   }
 
   @Test

--- a/src/test/java/org/sonar/plugins/findbugs/profiles/FindbugsSecurityMinimalProfileTest.java
+++ b/src/test/java/org/sonar/plugins/findbugs/profiles/FindbugsSecurityMinimalProfileTest.java
@@ -54,5 +54,7 @@ class FindbugsSecurityMinimalProfileTest {
     assertThat(profile.rules().stream().filter(r -> r.repoKey().equals(FindbugsRulesDefinition.REPOSITORY_KEY)).count()).isEqualTo(8);
     // 94 rules total - 8 fb = 86
     assertThat(profile.rules().stream().filter(r -> r.repoKey().equals(FindSecurityBugsRulesDefinition.REPOSITORY_KEY)).count()).isEqualTo(96);
+
+    FindbugsProfileTest.assertHasOnlyRulesForLanguage(profile.rules(), Java.KEY);
   }
 }


### PR DESCRIPTION
Test that we can upgrade from 4.0.6 and that profiles only contain rules for the relevant language