### PR TITLE
deps: remove sonar-java plugin dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -395,7 +395,6 @@
           <pluginDescription>Analyze Java, Scala, Closure and JSP code with SpotBugs. ${spotbugs.version}</pluginDescription>
           <pluginClass>org.sonar.plugins.findbugs.FindbugsPlugin</pluginClass>
           <useChildFirstClassLoader>false</useChildFirstClassLoader>
-          <requirePlugins>java:${sonar-java.version}</requirePlugins>
         </configuration>
       </plugin>
       <plugin>


### PR DESCRIPTION
Need to remove the plugin dependency from the manifest of the plugin because the sonar-java is no longer part of the marketplace (per SonarSource request)