### PR TITLE
Release 4.1.4

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -99,3 +99,5 @@ jobs:
           sonar-cloud-url: https://sonarcloud.io/summary/new_code?id=com.github.spotbugs%3Asonar-findbugs-plugin
           github-token: ${{ secrets.PAT_TO_FORK }}
           discourse-api-key: ${{ secrets.DISCOURSE_API_KEY }}
+          skip-creating-pull-request: true
+          skip-announcing: true

--- a/README.md
+++ b/README.md
@@ -51,5 +51,5 @@ Findbugs Plugin version|Embedded SpotBugs/Findbugs version|Embedded Findsecbugs 
 4.0.4                  | 4.4.0 (SpotBugs)                 | 1.11.0                     | 7.4.7 (sb-contrib)        | 1.8|7.9~|5.10.1.16922
 4.0.5                  | 4.5.0 (SpotBugs)                 | 1.11.0                     | 7.4.7 (sb-contrib)        | 1.8|7.9~|5.10.1.16922
 4.0.6                  | 4.5.2 (SpotBugs)                 | 1.11.0                     | 7.4.7 (sb-contrib)        | 1.8|7.9~|5.10.1.16922
-4.1.0                  | 4.6.0 (SpotBugs)                 | 1.12.0                     | 7.4.7 (sb-contrib)        | 1.8|7.9~|5.10.1.16922
-4.1.4-SNAPSHOT         | 4.6.0 (SpotBugs)                 | 1.12.0                     | 7.4.7 (sb-contrib)        | 1.8|7.9~|5.10.1.16922
+4.1.4                  | 4.6.0 (SpotBugs)                 | 1.12.0                     | 7.4.7 (sb-contrib)        | 1.8|7.9~|5.10.1.16922
+4.1.5-SNAPSHOT         | 4.6.0 (SpotBugs)                 | 1.12.0                     | 7.4.7 (sb-contrib)        | 1.8|7.9~|5.10.1.16922

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>com.github.spotbugs</groupId>
   <artifactId>sonar-findbugs-plugin</artifactId>
-  <version>4.1.4</version>
+  <version>4.1.5-SNAPSHOT</version>
   <packaging>sonar-plugin</packaging>
 
   <name>SonarQube SpotBugs Plugin</name>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>com.github.spotbugs</groupId>
   <artifactId>sonar-findbugs-plugin</artifactId>
-  <version>4.1.4-SNAPSHOT</version>
+  <version>4.1.4</version>
   <packaging>sonar-plugin</packaging>
 
   <name>SonarQube SpotBugs Plugin</name>


### PR DESCRIPTION
We need to remove the plugin dependency to sonar-java: https://community.sonarsource.com/t/new-release-sonar-findbugs-plugin-4-1-3/61969/6