### PR TITLE
Test against sonarqube 9.5

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,7 +36,7 @@ jobs:
             SONAR_JAVA_VERSION: 7.11.0.29148
           # latest 9.x
           - SONAR_SERVER_VERSION: 9.5.0.56709
-            SONAR_PLUGIN_API_VERSION: 9.5.0.71
+            SONAR_PLUGIN_API_VERSION: 9.6.1.114
             SONAR_PLUGIN_API_GROUPID: org.sonarsource.api.plugin
             SONAR_JAVA_VERSION: 7.12.0.29739
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,14 +20,21 @@ jobs:
       matrix:
         include:
           # previous LTS version
-          - SONAR_VERSION: 7.9
+          - SONAR_SERVER_VERSION: 7.9
+            SONAR_PLUGIN_API_VERSION: 7.9
             SONAR_JAVA_VERSION: 5.13.1.18282
           # current LTS version
-          - SONAR_VERSION: 8.9
+          - SONAR_SERVER_VERSION: 8.9.9.56886
+            SONAR_PLUGIN_API_VERSION: 8.9.9.56886
             SONAR_JAVA_VERSION: 6.15.1.26025
           # Sonarqube version 9 removed some deprecated APIs
-          - SONAR_VERSION: 9.4.0.54424
+          - SONAR_SERVER_VERSION: 9.4.0.54424
+            SONAR_PLUGIN_API_VERSION: 9.4.0.54424
             SONAR_JAVA_VERSION: 7.11.0.29148
+          # latest 9.x
+          - SONAR_SERVER_VERSION: 9.5.0.56709
+            SONAR_PLUGIN_API_VERSION: 9.5.0.56709
+            SONAR_JAVA_VERSION: 7.12.0.29739
     steps:
       - uses: actions/checkout@v2
         with:
@@ -48,7 +55,10 @@ jobs:
           restore-keys: ${{ runner.os }}-sonar
       - name: Build
         run: |
-          mvn verify -B -e -V
+          mvn verify -B -e -V \
+            -Dsonar.server.version=${{ env.SONAR_SERVER_VERSION }} \
+            -Dsonar-plugin-api.version=${{ env.SONAR_PLUGIN_API_VERSION }} \
+            -Dsonar-java.version=${{ env.SONAR_JAVA_VERSION }}
   deploy:
     runs-on: ubuntu-latest
     needs: build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,7 +36,7 @@ jobs:
             SONAR_JAVA_VERSION: 7.11.0.29148
           # latest 9.x
           - SONAR_SERVER_VERSION: 9.5.0.56709
-            SONAR_PLUGIN_API_VERSION: 9.6.1.114
+            SONAR_PLUGIN_API_VERSION: 9.5.0.71
             SONAR_PLUGIN_API_GROUPID: org.sonarsource.api.plugin
             SONAR_JAVA_VERSION: 7.12.0.29739
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,18 +22,22 @@ jobs:
           # previous LTS version
           - SONAR_SERVER_VERSION: 7.9
             SONAR_PLUGIN_API_VERSION: 7.9
+            SONAR_PLUGIN_API_GROUPID: org.sonarsource.sonarqube
             SONAR_JAVA_VERSION: 5.13.1.18282
           # current LTS version
           - SONAR_SERVER_VERSION: 8.9.9.56886
             SONAR_PLUGIN_API_VERSION: 8.9.9.56886
+            SONAR_PLUGIN_API_GROUPID: org.sonarsource.sonarqube
             SONAR_JAVA_VERSION: 6.15.1.26025
           # Sonarqube version 9 removed some deprecated APIs
           - SONAR_SERVER_VERSION: 9.4.0.54424
             SONAR_PLUGIN_API_VERSION: 9.4.0.54424
+            SONAR_PLUGIN_API_GROUPID: org.sonarsource.sonarqube
             SONAR_JAVA_VERSION: 7.11.0.29148
           # latest 9.x
           - SONAR_SERVER_VERSION: 9.5.0.56709
-            SONAR_PLUGIN_API_VERSION: 9.5.0.56709
+            SONAR_PLUGIN_API_VERSION: 9.5.0.71
+            SONAR_PLUGIN_API_GROUPID: org.sonarsource.api.plugin
             SONAR_JAVA_VERSION: 7.12.0.29739
     steps:
       - uses: actions/checkout@v2
@@ -58,6 +62,7 @@ jobs:
           mvn verify -B -e -V \
             -Dsonar.server.version=${{ matrix.SONAR_SERVER_VERSION }} \
             -Dsonar-plugin-api.version=${{ matrix.SONAR_PLUGIN_API_VERSION }} \
+            -Dsonar-plugin-api.groupId=${{ matrix.SONAR_PLUGIN_API_GROUPID }} \
             -Dsonar-java.version=${{ matrix.SONAR_JAVA_VERSION }}
   deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,9 +56,9 @@ jobs:
       - name: Build
         run: |
           mvn verify -B -e -V \
-            -Dsonar.server.version=${{ env.SONAR_SERVER_VERSION }} \
-            -Dsonar-plugin-api.version=${{ env.SONAR_PLUGIN_API_VERSION }} \
-            -Dsonar-java.version=${{ env.SONAR_JAVA_VERSION }}
+            -Dsonar.server.version=${{ matrix.SONAR_SERVER_VERSION }} \
+            -Dsonar-plugin-api.version=${{ matrix.SONAR_PLUGIN_API_VERSION }} \
+            -Dsonar-java.version=${{ matrix.SONAR_JAVA_VERSION }}
   deploy:
     runs-on: ubuntu-latest
     needs: build

--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -30,6 +30,7 @@ jobs:
       # previous LTS version
       SONAR_SERVER_VERSION: 8.9.9.56886
       SONAR_PLUGIN_API_VERSION: 8.9.9.56886
+      SONAR_PLUGIN_API_GROUPID: org.sonarsource.sonarqube
       SONAR_JAVA_VERSION: 6.15.1.26025
     steps:
       - name: Decide the ref to check out
@@ -61,6 +62,7 @@ jobs:
           mvn org.jacoco:jacoco-maven-plugin:prepare-agent verify sonar:sonar -B -e -V -DskipITs \
             -Dsonar.server.version=${{ env.SONAR_SERVER_VERSION }} \
             -Dsonar-plugin-api.version=${{ env.SONAR_PLUGIN_API_VERSION }} \
+            -Dsonar-plugin-api.groupId=${{ matrix.SONAR_PLUGIN_API_GROUPID }} \
             -Dsonar-java.version=${{ env.SONAR_JAVA_VERSION }}
             -Dsonar.projectKey=com.github.spotbugs:sonar-findbugs-plugin \
             -Dsonar.organization=spotbugs \

--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -28,7 +28,8 @@ jobs:
     runs-on: ubuntu-20.04
     env:
       # previous LTS version
-      SONAR_VERSION: 8.9.8.54436
+      SONAR_SERVER_VERSION: 8.9.9.56886
+      SONAR_PLUGIN_API_VERSION: 8.9.9.56886
       SONAR_JAVA_VERSION: 6.15.1.26025
     steps:
       - name: Decide the ref to check out
@@ -58,8 +59,9 @@ jobs:
       - name: Build
         run: |
           mvn org.jacoco:jacoco-maven-plugin:prepare-agent verify sonar:sonar -B -e -V -DskipITs \
-            -Dsonar.version=${{ env.SONAR_VERSION }} \
-            -Dsonar-java.version=${{ env.SONAR_JAVA_VERSION }} \
+            -Dsonar.server.version=${{ env.SONAR_SERVER_VERSION }} \
+            -Dsonar-plugin-api.version=${{ env.SONAR_PLUGIN_API_VERSION }} \
+            -Dsonar-java.version=${{ env.SONAR_JAVA_VERSION }}
             -Dsonar.projectKey=com.github.spotbugs:sonar-findbugs-plugin \
             -Dsonar.organization=spotbugs \
             -Dsonar.host.url=https://sonarcloud.io \

--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,8 @@
     <jdk.min.version>1.8</jdk.min.version>
     <surefire.version>3.0.0-M5</surefire.version>
     <failsafe.version>3.0.0-M5</failsafe.version>
-    <sonar.version>7.9</sonar.version>
+    <sonar.server.version>7.9</sonar.server.version>
+    <sonar-plugin-api.version>7.9</sonar-plugin-api.version>
     <sonar-java.version>5.13.1.18282</sonar-java.version>
 
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -145,7 +146,7 @@
     <dependency>
       <groupId>org.sonarsource.sonarqube</groupId>
       <artifactId>sonar-plugin-api</artifactId>
-      <version>${sonar.version}</version>
+      <version>${sonar-plugin-api.version}</version>
       <scope>provided</scope>
       <exclusions>
         <!-- allows to package xstream into plugin -->
@@ -346,7 +347,7 @@
           <disableModules>false</disableModules>
           <useModulePath>false</useModulePath>
           <systemPropertyVariables>
-            <sonar.version>${sonar.version}</sonar.version>
+            <sonar.server.version>${sonar.server.version}</sonar.server.version>
           </systemPropertyVariables>
         </configuration>
         <executions>

--- a/pom.xml
+++ b/pom.xml
@@ -61,6 +61,7 @@
     <failsafe.version>3.0.0-M5</failsafe.version>
     <sonar.server.version>7.9</sonar.server.version>
     <sonar-plugin-api.version>7.9</sonar-plugin-api.version>
+    <sonar-plugin-api.groupId>org.sonarsource.sonarqube</sonar-plugin-api.groupId>
     <sonar-java.version>5.13.1.18282</sonar-java.version>
 
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -144,7 +145,7 @@
     </dependency>
 
     <dependency>
-      <groupId>org.sonarsource.sonarqube</groupId>
+      <groupId>${sonar-plugin-api.groupId}</groupId>
       <artifactId>sonar-plugin-api</artifactId>
       <version>${sonar-plugin-api.version}</version>
       <scope>provided</scope>

--- a/src/test/java/org/sonar/plugins/findbugs/it/FindbugsTestSuite.java
+++ b/src/test/java/org/sonar/plugins/findbugs/it/FindbugsTestSuite.java
@@ -46,7 +46,7 @@ public class FindbugsTestSuite {
 
   static {
     // build, start and stop the orchestrator here, making sure that it happens exactly once whether we run one or multiple tests
-    String sonarVersion = System.getProperty("sonar.version", "8.9");
+    String sonarVersion = System.getProperty("sonar.server.version", "8.9");
     
     // We will test here the case where an older version of the plugin was already installed and upgrade it
     // This should be its own test case but it takes a long time to build a server so we're doing it here


### PR DESCRIPTION
With 9.5 SonarSource announced that "The sonar-plugin-api is now released independently" and there's a 9.6 version of the API already.
Decouple the properties for the sonar server version and the sonar plugin API version