### PR TITLE
feature: log the plugin version

### DIFF
--- a/src/main/java/org/sonar/plugins/findbugs/FindbugsSensor.java
+++ b/src/main/java/org/sonar/plugins/findbugs/FindbugsSensor.java
@@ -122,7 +122,7 @@ public class FindbugsSensor implements Sensor {
 
   @Override
   public void execute(SensorContext context) {
-
+    LOG.info("Findbugs plugin version: {}", FindbugsVersion.getVersion());
     if (!hasActiveFindbugsRules() && !hasActiveFbContribRules() && !hasActiveFindSecBugsRules()) {
       return;
     }

--- a/src/main/java/org/sonar/plugins/findbugs/FindbugsVersion.java
+++ b/src/main/java/org/sonar/plugins/findbugs/FindbugsVersion.java
@@ -19,12 +19,11 @@
  */
 package org.sonar.plugins.findbugs;
 
-import org.apache.commons.io.IOUtils;
-import org.slf4j.LoggerFactory;
-
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Properties;
+
+import org.slf4j.LoggerFactory;
 
 public enum FindbugsVersion {
   INSTANCE;
@@ -37,20 +36,14 @@ public enum FindbugsVersion {
   }
 
   private FindbugsVersion() {
-    InputStream input = getClass().getResourceAsStream(PROPERTIES_PATH);
-    try {
+    try (InputStream input = getClass().getResourceAsStream(PROPERTIES_PATH)) {
       Properties properties = new Properties();
       properties.load(input);
-      this.version = properties.getProperty("findbugs.version");
-
+      this.version = properties.getProperty("findbugs.plugin.version");
     } catch (IOException e) {
       LoggerFactory.getLogger(getClass()).warn("Can not load the Findbugs version from the file " + PROPERTIES_PATH);
       LoggerFactory.getLogger(getClass()).debug("Error while loading propoerties", e);
       this.version = "";
-
-    } finally {
-      IOUtils.closeQuietly(input);
     }
   }
-
 }

--- a/src/main/resources/org/sonar/plugins/findbugs/findbugs-plugin.properties
+++ b/src/main/resources/org/sonar/plugins/findbugs/findbugs-plugin.properties
@@ -1,1 +1,2 @@
-findbugs.version=${findbugs.version}
+# findbugs.plugin.version will be populated by Maven
+findbugs.plugin.version=${project.version}


### PR DESCRIPTION
Many users don't know the version they are using because they do not have access to the SonarQube server administration page. Log the version so we don't waste time while they ask they ask their administrator