### PR TITLE
test: remove java 11 usage in unit tests

### DIFF
--- a/src/test/java/org/sonar/plugins/findbugs/it/FindbugsTestSuite.java
+++ b/src/test/java/org/sonar/plugins/findbugs/it/FindbugsTestSuite.java
@@ -37,8 +37,8 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.nio.file.FileSystems;
 import java.nio.file.Files;
-import java.nio.file.Path;
 
 public class FindbugsTestSuite {
 
@@ -69,7 +69,7 @@ public class FindbugsTestSuite {
     try (OutputStream out = new FileOutputStream(pluginTargetFile)) {
       // Delete the old version of the plugin
       Files.delete(ORCHESTRATOR.getServer().getHome().toPath().resolve("extensions/plugins/sonar-findbugs-plugin-4.0.6.jar"));
-      Files.copy(Path.of("target", "sonar-findbugs-plugin.jar"), out);
+      Files.copy(FileSystems.getDefault().getPath("target", "sonar-findbugs-plugin.jar"), out);
     } catch (IOException e) {
       throw new RuntimeException(e);
     }

--- a/src/test/java/org/sonar/plugins/findbugs/resource/ByteCodeResourceLocatorTest.java
+++ b/src/test/java/org/sonar/plugins/findbugs/resource/ByteCodeResourceLocatorTest.java
@@ -11,8 +11,6 @@ import org.sonar.plugins.java.api.JavaResourceLocator;
 
 import java.io.File;
 import java.io.IOException;
-import java.net.URI;
-import java.net.URISyntaxException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -131,10 +129,9 @@ class ByteCodeResourceLocatorTest {
   @Test
   void findClassFileByClassName() throws IOException {
     JavaResourceLocator javaResourceLocator = mock(JavaResourceLocator.class);
-    InputFile inputFile = mock(InputFile.class);
     
-    Path folderPath = Files.createDirectories(temp.toPath().resolve(Path.of("foo", "bar")));
-    Path testFolderPath = Files.createDirectories(temp.toPath().resolve(Path.of("test", "123")));
+    Path folderPath = Files.createDirectories(temp.toPath().resolve("foo").resolve("bar"));
+    Path testFolderPath = Files.createDirectories(temp.toPath().resolve("test").resolve("123"));
     Path filePath = Files.createFile(folderPath.resolve("Test.class"));
     
     when(javaResourceLocator.classpath()).thenReturn(Arrays.asList(testFolderPath.toFile(), filePath.toFile(), temp));


### PR DESCRIPTION
Path.of() was added in Java 11. Even if the build runs on Java 11 the
project is on Java 8