### PR TITLE
tests: Run the integrations tests against SQ 9.8

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,14 +30,14 @@ jobs:
             SONAR_PLUGIN_API_VERSION: 8.9.9.56886
             SONAR_PLUGIN_API_GROUPID: org.sonarsource.sonarqube
             SONAR_JAVA_VERSION: 6.15.1.26025
-          - SONAR_SERVER_VERSION: 9.6.0.59041
-            SONAR_PLUGIN_API_VERSION: 9.9.0.229
-            SONAR_PLUGIN_API_GROUPID: org.sonarsource.api.plugin
-            SONAR_JAVA_VERSION: 7.13.0.29990
           - SONAR_SERVER_VERSION: 9.7.0.61563
             SONAR_PLUGIN_API_VERSION: 9.11.0.290
             SONAR_PLUGIN_API_GROUPID: org.sonarsource.api.plugin
             SONAR_JAVA_VERSION: 7.14.0.30229
+          - SONAR_SERVER_VERSION: 9.8.0.63668
+            SONAR_PLUGIN_API_VERSION: 9.13.0.360
+            SONAR_PLUGIN_API_GROUPID: org.sonarsource.api.plugin
+            SONAR_JAVA_VERSION: 7.15.0.30507
     steps:
       - uses: actions/checkout@v3
         with:

--- a/pom.xml
+++ b/pom.xml
@@ -200,7 +200,7 @@
     <dependency>
       <groupId>org.sonarsource.orchestrator</groupId>
       <artifactId>sonar-orchestrator</artifactId>
-      <version>3.37.0.87</version>
+      <version>3.40.0.183</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/src/test/java/org/sonar/plugins/findbugs/it/FindbugsTestSuite.java
+++ b/src/test/java/org/sonar/plugins/findbugs/it/FindbugsTestSuite.java
@@ -56,6 +56,8 @@ public class FindbugsTestSuite {
         // Build the SonarQube server with an older version of the plugin
       .addPlugin(MavenLocation.of("com.github.spotbugs", "sonar-findbugs-plugin", "4.0.6"))
       .keepBundledPlugins()
+      // Since SQ 9.8 permissions for 'Anyone' group has been limited for new instances
+      .useDefaultAdminCredentialsForBuilds(true)
       .setSonarVersion("LATEST_RELEASE[" + sonarVersion + "]")
       .restoreProfileAtStartup(FileLocation.ofClasspath("/it/profiles/empty-backup.xml"))
       .restoreProfileAtStartup(FileLocation.ofClasspath("/it/profiles/findbugs-backup.xml"))


### PR DESCRIPTION
Since 9.8 the instance created for integration tests has the permission to run an analysis disabled by default, updated orchestrator so we can enable the permission