### PR TITLE
fix: stop updating the security manager

### DIFF
--- a/src/main/java/org/sonar/plugins/findbugs/FindbugsExecutor.java
+++ b/src/main/java/org/sonar/plugins/findbugs/FindbugsExecutor.java
@@ -100,9 +100,6 @@ public class FindbugsExecutor {
   }
 
   public Collection<ReportedBug> execute(boolean useFbContrib, boolean useFindSecBugs) {
-    // We keep a handle on the current security manager because FB plays with it and we need to restore it before shutting down the executor
-    // service
-    SecurityManager currentSecurityManager = System.getSecurityManager();
     ClassLoader initialClassLoader = Thread.currentThread().getContextClassLoader();
     Thread.currentThread().setContextClassLoader(FindBugs2.class.getClassLoader());
 
@@ -187,8 +184,6 @@ public class FindbugsExecutor {
     } catch (Exception e) {
       throw new IllegalStateException("Can not execute Findbugs", e);
     } finally {
-      // we set back the original security manager BEFORE shutting down the executor service, otherwise there's a problem with Java 5
-      System.setSecurityManager(currentSecurityManager);
       resetCustomPluginList(customPlugins);
       executorService.shutdown();
       IOUtils.closeQuietly(xmlOutput);


### PR DESCRIPTION
Since SpotBugs 4.7.3 and https://github.com/spotbugs/spotbugs/pull/2123 it is no longer necessary to set the security manager6