### PR TITLE
deps: upgrade xstream to 1.4.20

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -135,7 +135,7 @@
     <dependency>
       <groupId>com.thoughtworks.xstream</groupId>
       <artifactId>xstream</artifactId>
-      <version>1.4.19</version>
+      <version>1.4.20</version>
       <exclusions>
         <!-- we use stax -->
         <exclusion>


### PR DESCRIPTION
Upgrade xstream to solve CVE-2022-41966