### PR TITLE
deps: revert to using the ASM version provided by SpotBugs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,6 @@
     <spotbugs.version>4.8.1</spotbugs.version>
     <sbcontrib.version>7.6.0</sbcontrib.version>
     <findsecbugs.version>1.12.0</findsecbugs.version>
-    <asm.version>9.6</asm.version>
 
     <jdk.min.version>1.8</jdk.min.version>
     <surefire.version>3.2.2</surefire.version>
@@ -72,18 +71,6 @@
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
   </properties>
-
-  <dependencyManagement>
-    <dependencies>
-      <dependency>
-        <groupId>org.ow2.asm</groupId>
-        <artifactId>asm-bom</artifactId>
-        <version>${asm.version}</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
-    </dependencies>
-  </dependencyManagement>
 
   <dependencies>
     <!--


### PR DESCRIPTION
Now that SpotBugs is upgraded to 4.8.1 we can revert to using the transient ASM dependency version (i.e. 9.6)