### PR TITLE
Report analysis errors

### DIFF
--- a/src/main/java/org/sonar/plugins/findbugs/AnalysisResult.java
+++ b/src/main/java/org/sonar/plugins/findbugs/AnalysisResult.java
@@ -1,0 +1,55 @@
+/*
+ * SonarQube Findbugs Plugin
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
+ */
+package org.sonar.plugins.findbugs;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+
+import edu.umd.cs.findbugs.AnalysisError;
+import edu.umd.cs.findbugs.BugInstance;
+
+/**
+ * @author gtoison
+ *
+ */
+public class AnalysisResult {
+  private Collection<ReportedBug> reportedBugs;
+  private Collection<AnalysisError> analysisErrors;
+  
+  public AnalysisResult() {
+    this(new ArrayList<>(), new ArrayList<>());
+  }
+  
+  public AnalysisResult(BugInstance bugInstance) {
+    this(Arrays.asList(new ReportedBug(bugInstance)), new ArrayList<>());
+  }
+  
+  public AnalysisResult(Collection<ReportedBug> reportedBugs, Collection<? extends AnalysisError> errors) {
+    this.reportedBugs = reportedBugs;
+    this.analysisErrors = new ArrayList<>(errors);
+  }
+
+  public Collection<ReportedBug> getReportedBugs() {
+    return reportedBugs;
+  }
+  
+  public Collection<AnalysisError> getAnalysisErrors() {
+    return analysisErrors;
+  }
+}

--- a/src/main/java/org/sonar/plugins/findbugs/FindbugsSensor.java
+++ b/src/main/java/org/sonar/plugins/findbugs/FindbugsSensor.java
@@ -24,7 +24,6 @@ import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.PrintWriter;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.SortedSet;
@@ -38,6 +37,7 @@ import org.sonar.api.batch.rule.ActiveRules;
 import org.sonar.api.batch.sensor.Sensor;
 import org.sonar.api.batch.sensor.SensorContext;
 import org.sonar.api.batch.sensor.SensorDescriptor;
+import org.sonar.api.batch.sensor.error.NewAnalysisError;
 import org.sonar.api.batch.sensor.issue.NewIssue;
 import org.sonar.api.batch.sensor.issue.NewIssueLocation;
 import org.sonar.plugins.findbugs.language.Jsp;
@@ -51,6 +51,8 @@ import org.sonar.plugins.findbugs.rules.FindSecurityBugsRulesDefinition;
 import org.sonar.plugins.findbugs.rules.FindSecurityBugsScalaRulesDefinition;
 import org.sonar.plugins.findbugs.rules.FindbugsRulesDefinition;
 import org.sonar.plugins.java.api.JavaResourceLocator;
+
+import edu.umd.cs.findbugs.AnalysisError;
 
 public class FindbugsSensor implements Sensor {
 
@@ -127,11 +129,11 @@ public class FindbugsSensor implements Sensor {
       return;
     }
 
-    Collection<ReportedBug> collection = executor.execute(hasActiveFbContribRules(), hasActiveFindSecBugsRules());
+    AnalysisResult analysisResult = executor.execute(hasActiveFbContribRules(), hasActiveFindSecBugsRules());
 
     try {
 
-      for (ReportedBug bugInstance : collection) {
+      for (ReportedBug bugInstance : analysisResult.getReportedBugs()) {
 
         try {
           ActiveRule rule = null;
@@ -224,6 +226,9 @@ public class FindbugsSensor implements Sensor {
         }
       }
 
+      for (AnalysisError analysisError : analysisResult.getAnalysisErrors()) {
+        insertAnalysisError(context, analysisError);
+      }
     }
     finally {
       if(classMappingWriter != null) {
@@ -233,6 +238,31 @@ public class FindbugsSensor implements Sensor {
     }
   }
 
+  public void insertAnalysisError(SensorContext context, AnalysisError analysisError) {
+    NewAnalysisError error = context.newAnalysisError();
+
+    StringBuilder message = buildAnalysisErrorMessage(analysisError);
+    error.message(message.toString());
+
+    error.save();
+  }
+
+  public StringBuilder buildAnalysisErrorMessage(AnalysisError analysisError) {
+    StringBuilder message = new StringBuilder(analysisError.getMessage());
+    if (analysisError.getStackTrace() != null) {
+      for (String trace : analysisError.getStackTrace()) {
+        message.append('\n');
+        message.append(trace);
+      }
+    }
+    if (analysisError.getNestedStackTrace() != null) {
+      for (String trace : analysisError.getNestedStackTrace()) {
+        message.append('\n');
+        message.append(trace);
+      }
+    }
+    return message;
+  }
 
   protected void insertIssue(ActiveRule rule, InputFile resource, int line, String message, ReportedBug bugInstance) {
     NewIssue newIssue = sensorContext.newIssue().forRule(rule.ruleKey());

--- a/src/test/java/org/sonar/plugins/findbugs/FindbugsExecutorTest.java
+++ b/src/test/java/org/sonar/plugins/findbugs/FindbugsExecutorTest.java
@@ -77,7 +77,7 @@ class FindbugsExecutorTest {
     File reportFile = new File(temporaryFolder, "findbugs-report.xml");
     when(conf.getTargetXMLReport()).thenReturn(reportFile);
 
-    new FindbugsExecutor(conf, fsEmpty, configEmpty).execute();
+    AnalysisResult analysisResult = new FindbugsExecutor(conf, fsEmpty, configEmpty).execute();
 
     assertThat(reportFile).exists();
     String report = FileUtils.readFileToString(reportFile, StandardCharsets.UTF_8);
@@ -87,6 +87,8 @@ class FindbugsExecutorTest {
     .as("Report should be generated with messages").contains("<Message>")
     .contains("priority=\"1\"")
     .doesNotContain("priority=\"3\"");
+
+    checkAnalysisResult(analysisResult);
   }
 
   @Test
@@ -96,7 +98,7 @@ class FindbugsExecutorTest {
     when(conf.getTargetXMLReport()).thenReturn(reportFile);
     when(conf.getConfidenceLevel()).thenReturn("low");
 
-    new FindbugsExecutor(conf, fsEmpty, configEmpty).execute();
+    AnalysisResult analysisResult = new FindbugsExecutor(conf, fsEmpty, configEmpty).execute();
 
     assertThat(reportFile).exists();
     String report = FileUtils.readFileToString(reportFile, StandardCharsets.UTF_8);
@@ -106,6 +108,8 @@ class FindbugsExecutorTest {
     .as("Report should be generated with messages").contains("<Message>")
     .contains("priority=\"1\"")
     .contains("priority=\"3\"");
+    
+    checkAnalysisResult(analysisResult);
   }
 
   public void shouldTerminateAfterTimeout() throws Exception {
@@ -148,4 +152,13 @@ class FindbugsExecutorTest {
     return conf;
   }
 
+  /**
+   * Smoke test checking that no errors where reported.
+   * This might happen when upgrading to a new version of SpotBugs or plugins and would most likely mean that there's a regression in the new version
+   * 
+   * @param analysisResult
+   */
+  public void checkAnalysisResult(AnalysisResult analysisResult) {
+    assertThat(analysisResult.getAnalysisErrors()).isEmpty();
+  }
 }


### PR DESCRIPTION
Analysis errors caught during by SpotBugs are logged by the sensor but not reported on the Sonarqube server.
Collect the errors and report them in the sensor context so they are reflected on the server.