### PR TITLE
Add the plugin version to the analysis error messages

### DIFF
--- a/src/main/java/org/sonar/plugins/findbugs/FindbugsSensor.java
+++ b/src/main/java/org/sonar/plugins/findbugs/FindbugsSensor.java
@@ -249,6 +249,8 @@ public class FindbugsSensor implements Sensor {
 
   public StringBuilder buildAnalysisErrorMessage(AnalysisError analysisError) {
     StringBuilder message = new StringBuilder(analysisError.getMessage());
+    message.append("Findbugs plugin version: " + FindbugsVersion.getVersion());
+    
     if (analysisError.getStackTrace() != null) {
       for (String trace : analysisError.getStackTrace()) {
         message.append('\n');


### PR DESCRIPTION
In SonarQube the plugin version is only available in the admin pages