### PR TITLE
build: replaced deprecated set-output

### DIFF
--- a/.github/actions/sonar-update-center/.github/workflows/integrationTest.yml
+++ b/.github/actions/sonar-update-center/.github/workflows/integrationTest.yml
@@ -13,13 +13,10 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.event.workflow_run.head_sha }}
-      - name: Read .nvmrc
-        run: echo ::set-output name=NVMRC::$(cat .nvmrc)
-        id: nvm
       - name: Setup node
         uses: actions/setup-node@v4
         with:
-          node-version: '${{ steps.nvm.outputs.NVMRC }}'
+          node-version-file: '.nvmrc'
           cache: npm
       - run: |
           npm ci


### PR DESCRIPTION
`set-output` is deprecated, see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/