### PR TITLE
Bundle sonar-java and dependencies

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,16 +24,13 @@ jobs:
           # 9.9 LTS 
           - SONAR_SERVER_VERSION: 9.9.0.65466
             SONAR_PLUGIN_API_VERSION: 9.14.0.375
-            SONAR_PLUGIN_API_GROUPID: org.sonarsource.api.plugin
             SONAR_SERVER_JAVA_VERSION: 17
           # 10.x 
           - SONAR_SERVER_VERSION: 10.4.0.87286
             SONAR_PLUGIN_API_VERSION: 10.6.0.2114
-            SONAR_PLUGIN_API_GROUPID: org.sonarsource.api.plugin
             SONAR_SERVER_JAVA_VERSION: 17
           - SONAR_SERVER_VERSION: 10.6.0.92116
             SONAR_PLUGIN_API_VERSION: 10.7.0.2191
-            SONAR_PLUGIN_API_GROUPID: org.sonarsource.api.plugin
             SONAR_SERVER_JAVA_VERSION: 17
           # https://mvnrepository.com/artifact/org.sonarsource.sonarqube/sonar-core
           # https://mvnrepository.com/artifact/org.sonarsource.api.plugin/sonar-plugin-api
@@ -60,8 +57,7 @@ jobs:
         run: |
           ./mvnw verify -B -e -V \
             -Dsonar.server.version=${{ matrix.SONAR_SERVER_VERSION }} \
-            -Dsonar-plugin-api.version=${{ matrix.SONAR_PLUGIN_API_VERSION }} \
-            -Dsonar-plugin-api.groupId=${{ matrix.SONAR_PLUGIN_API_GROUPID }}
+            -Dsonar-plugin-api.version=${{ matrix.SONAR_PLUGIN_API_VERSION }}
   deploy:
     runs-on: ubuntu-latest
     needs: build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,22 +18,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         include:
-          # previous LTS version
-          - SONAR_SERVER_VERSION: 7.9
-            SONAR_PLUGIN_API_VERSION: 7.9
-            SONAR_PLUGIN_API_GROUPID: org.sonarsource.sonarqube
-            SONAR_SERVER_JAVA_VERSION: 11
-          # current LTS version
-          - SONAR_SERVER_VERSION: 8.9.9.56886
-            SONAR_PLUGIN_API_VERSION: 8.9.9.56886
-            SONAR_PLUGIN_API_GROUPID: org.sonarsource.sonarqube
-            SONAR_SERVER_JAVA_VERSION: 11
-          - SONAR_SERVER_VERSION: 9.7.0.61563
-            SONAR_PLUGIN_API_VERSION: 9.11.0.290
-            SONAR_PLUGIN_API_GROUPID: org.sonarsource.api.plugin
-            SONAR_SERVER_JAVA_VERSION: 11
           # 9.9 LTS 
           - SONAR_SERVER_VERSION: 9.9.0.65466
             SONAR_PLUGIN_API_VERSION: 9.14.0.375

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,35 +24,29 @@ jobs:
           - SONAR_SERVER_VERSION: 7.9
             SONAR_PLUGIN_API_VERSION: 7.9
             SONAR_PLUGIN_API_GROUPID: org.sonarsource.sonarqube
-            SONAR_JAVA_VERSION: 5.13.1.18282
             SONAR_SERVER_JAVA_VERSION: 11
           # current LTS version
           - SONAR_SERVER_VERSION: 8.9.9.56886
             SONAR_PLUGIN_API_VERSION: 8.9.9.56886
             SONAR_PLUGIN_API_GROUPID: org.sonarsource.sonarqube
-            SONAR_JAVA_VERSION: 6.15.1.26025
             SONAR_SERVER_JAVA_VERSION: 11
           - SONAR_SERVER_VERSION: 9.7.0.61563
             SONAR_PLUGIN_API_VERSION: 9.11.0.290
             SONAR_PLUGIN_API_GROUPID: org.sonarsource.api.plugin
-            SONAR_JAVA_VERSION: 7.14.0.30229
             SONAR_SERVER_JAVA_VERSION: 11
           # 9.9 LTS 
           - SONAR_SERVER_VERSION: 9.9.0.65466
             SONAR_PLUGIN_API_VERSION: 9.14.0.375
             SONAR_PLUGIN_API_GROUPID: org.sonarsource.api.plugin
-            SONAR_JAVA_VERSION: 7.16.0.30901
             SONAR_SERVER_JAVA_VERSION: 17
           # 10.x 
           - SONAR_SERVER_VERSION: 10.4.0.87286
             SONAR_PLUGIN_API_VERSION: 10.6.0.2114
             SONAR_PLUGIN_API_GROUPID: org.sonarsource.api.plugin
-            SONAR_JAVA_VERSION: 7.30.1.34514
             SONAR_SERVER_JAVA_VERSION: 17
           - SONAR_SERVER_VERSION: 10.6.0.92116
             SONAR_PLUGIN_API_VERSION: 10.7.0.2191
             SONAR_PLUGIN_API_GROUPID: org.sonarsource.api.plugin
-            SONAR_JAVA_VERSION: 8.0.1.36337
             SONAR_SERVER_JAVA_VERSION: 17
           # https://mvnrepository.com/artifact/org.sonarsource.sonarqube/sonar-core
           # https://mvnrepository.com/artifact/org.sonarsource.api.plugin/sonar-plugin-api
@@ -80,8 +74,7 @@ jobs:
           ./mvnw verify -B -e -V \
             -Dsonar.server.version=${{ matrix.SONAR_SERVER_VERSION }} \
             -Dsonar-plugin-api.version=${{ matrix.SONAR_PLUGIN_API_VERSION }} \
-            -Dsonar-plugin-api.groupId=${{ matrix.SONAR_PLUGIN_API_GROUPID }} \
-            -Dsonar-java.version=${{ matrix.SONAR_JAVA_VERSION }}
+            -Dsonar-plugin-api.groupId=${{ matrix.SONAR_PLUGIN_API_GROUPID }}
   deploy:
     runs-on: ubuntu-latest
     needs: build

--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -29,10 +29,8 @@ jobs:
     runs-on: ubuntu-latest
     env:
       # previous LTS version
-      SONAR_SERVER_VERSION: 8.9.9.56886
-      SONAR_PLUGIN_API_VERSION: 8.9.9.56886
-      SONAR_PLUGIN_API_GROUPID: org.sonarsource.sonarqube
-      SONAR_JAVA_VERSION: 6.15.1.26025
+      SONAR_SERVER_VERSION: 9.9.0.65466
+      SONAR_PLUGIN_API_VERSION: 9.14.0.375
     steps:
       - name: Decide the ref to check out
         uses: haya14busa/action-cond@v1
@@ -63,8 +61,6 @@ jobs:
           ./mvnw org.jacoco:jacoco-maven-plugin:prepare-agent verify sonar:sonar -B -e -V -DskipITs \
             -Dsonar.server.version=${{ env.SONAR_SERVER_VERSION }} \
             -Dsonar-plugin-api.version=${{ env.SONAR_PLUGIN_API_VERSION }} \
-            -Dsonar-plugin-api.groupId=${{ env.SONAR_PLUGIN_API_GROUPID }} \
-            -Dsonar-java.version=${{ env.SONAR_JAVA_VERSION }} \
             -Dsonar.projectKey=com.github.spotbugs:sonar-findbugs-plugin \
             -Dsonar.organization=spotbugs \
             -Dsonar.host.url=https://sonarcloud.io \

--- a/README.md
+++ b/README.md
@@ -75,4 +75,4 @@ Findbugs Plugin version|Embedded SpotBugs/Findbugs version|Embedded Findsecbugs 
 4.2.8                  | 4.8.3 (SpotBugs)                 | 1.13.0                     | 7.6.4 (sb-contrib)        | 1.8|7.9~|5.10.1.16922
 4.2.9                  | 4.8.4 (SpotBugs)                 | 1.13.0                     | 7.6.4 (sb-contrib)        | 1.8|7.9~|5.10.1.16922
 4.2.10                 | 4.8.6 (SpotBugs)                 | 1.13.0                     | 7.6.4 (sb-contrib)        | 1.8|7.9~|5.10.1.16922
-4.2.11-SNAPSHOT        | 4.8.6 (SpotBugs)                 | 1.13.0                     | 7.6.4 (sb-contrib)        | 1.8|7.9~|5.10.1.16922
+4.3.0-SNAPSHOT         | 4.8.6 (SpotBugs)                 | 1.13.0                     | 7.6.4 (sb-contrib)        |  17|9.9~|8.0.1.36337

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>com.github.spotbugs</groupId>
   <artifactId>sonar-findbugs-plugin</artifactId>
-  <version>4.2.11-SNAPSHOT</version>
+  <version>4.3.0-SNAPSHOT</version>
   <packaging>sonar-plugin</packaging>
 
   <name>SonarQube SpotBugs Plugin</name>
@@ -59,9 +59,8 @@
     <jdk.min.version>1.8</jdk.min.version>
     <surefire.version>3.2.5</surefire.version>
     <failsafe.version>3.2.5</failsafe.version>
-    <sonar.server.version>7.9</sonar.server.version>
-    <sonar-plugin-api.version>7.9.6</sonar-plugin-api.version>
-    <sonar-plugin-api.groupId>org.sonarsource.sonarqube</sonar-plugin-api.groupId>
+    <sonar.server.version>9.9.0.65466</sonar.server.version>
+    <sonar-plugin-api.version>9.14.0.375</sonar-plugin-api.version>
     <sonar-java.version>8.0.1.36337</sonar-java.version>
     
     <sonar-orchestrator.version>4.9.0.1920</sonar-orchestrator.version>
@@ -153,7 +152,7 @@
     </dependency>
 
     <dependency>
-      <groupId>${sonar-plugin-api.groupId}</groupId>
+      <groupId>org.sonarsource.api.plugin</groupId>
       <artifactId>sonar-plugin-api</artifactId>
       <version>${sonar-plugin-api.version}</version>
       <scope>provided</scope>

--- a/pom.xml
+++ b/pom.xml
@@ -62,7 +62,7 @@
     <sonar.server.version>7.9</sonar.server.version>
     <sonar-plugin-api.version>7.9.6</sonar-plugin-api.version>
     <sonar-plugin-api.groupId>org.sonarsource.sonarqube</sonar-plugin-api.groupId>
-    <sonar-java.version>5.14.0.18788</sonar-java.version>
+    <sonar-java.version>8.0.1.36337</sonar-java.version>
     
     <sonar-orchestrator.version>4.9.0.1920</sonar-orchestrator.version>
 
@@ -170,7 +170,44 @@
       <groupId>org.sonarsource.java</groupId>
       <artifactId>sonar-java-plugin</artifactId>
       <version>${sonar-java.version}</version>
-      <scope>provided</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>org.sonarsource.java</groupId>
+          <artifactId>external-reports</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.sonarsource.java</groupId>
+          <artifactId>java-checks</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.sonarsource.analyzer-commons</groupId>
+          <artifactId>sonar-xml-parsing</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.sonarsource.analyzer-commons</groupId>
+          <artifactId>sonar-analyzer-commons</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.sonarsource.java</groupId>
+          <artifactId>java-checks-aws</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.sonarsource.java</groupId>
+          <artifactId>java-jsp</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.sonarsource.analyzer-commons</groupId>
+          <artifactId>sonar-performance-measure</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.sonarsource.java</groupId>
+          <artifactId>java-surefire</artifactId>
+        </exclusion>
+        <!--<exclusion>
+          <groupId>org.sonarsource.java</groupId>
+          <artifactId>jdt-package</artifactId>
+        </exclusion>-->
+      </exclusions>
     </dependency>
 
     <!-- unit tests -->
@@ -421,6 +458,7 @@
           <pluginClass>org.sonar.plugins.findbugs.FindbugsPlugin</pluginClass>
           <useChildFirstClassLoader>false</useChildFirstClassLoader>
           <requiredForLanguages>java,scala,jsp,clojure,kotlin</requiredForLanguages>
+          <skipDependenciesPackaging>true</skipDependenciesPackaging>
         </configuration>
       </plugin>
       <plugin>
@@ -437,7 +475,7 @@
             <configuration>
               <rules>
                 <requireFilesSize>
-                  <maxsize>32000000</maxsize>
+                  <maxsize>42000000</maxsize>
                   <minsize>8000000</minsize>
                   <files>
                     <file>${project.build.directory}/${project.build.finalName}.jar</file>
@@ -459,22 +497,21 @@
               <goal>shade</goal>
             </goals>
             <configuration>
-              <artifactSet>
-                <includes>
-                  <include>commons-io:commons-io</include>
-                  <include>org.codehaus.sonar:sonar-channel</include>
-                </includes>
-              </artifactSet>
-              <relocations>
-                <relocation>
-                  <pattern>org.apache.commons.io</pattern>
-                  <shadedPattern>shaded.io</shadedPattern>
-                </relocation>
-                  <relocation>
-                    <pattern>org.sonar.channel</pattern>
-                    <shadedPattern>shaded.channel</shadedPattern>
-                  </relocation>
-              </relocations>
+              <transformers>
+                <transformer  implementation="org.apache.maven.plugins.shade.resource.ApacheNoticeResourceTransformer">
+                  <addHeader>false</addHeader>
+                </transformer>
+              </transformers>
+              <filters>
+                <filter>
+                  <artifact>*:*</artifact>
+                  <excludes>
+                    <exclude>META-INF/*.SF</exclude>
+                    <exclude>META-INF/*.DSA</exclude>
+                    <exclude>META-INF/*.RSA</exclude>
+                  </excludes>
+                </filter>
+              </filters>
               <createDependencyReducedPom>false</createDependencyReducedPom>
             </configuration>
           </execution>

--- a/src/main/java/org/sonar/plugins/findbugs/FindbugsConfiguration.java
+++ b/src/main/java/org/sonar/plugins/findbugs/FindbugsConfiguration.java
@@ -56,7 +56,6 @@ import org.sonar.api.config.Configuration;
 import org.sonar.api.config.PropertyDefinition;
 import org.sonar.api.resources.Qualifiers;
 import org.sonar.api.scan.filesystem.PathResolver;
-import org.sonar.api.utils.Version;
 import org.sonar.plugins.findbugs.classpath.ClasspathLocator;
 import org.sonar.plugins.findbugs.rules.FbContribRulesDefinition;
 import org.sonar.plugins.findbugs.rules.FindSecurityBugsRulesDefinition;
@@ -517,7 +516,7 @@ public class FindbugsConfiguration implements Startable {
 
   public static List<PropertyDefinition> getPropertyDefinitions(Context context) {
     String subCategory = "FindBugs";
-    List<PropertyDefinition> properties = Arrays.asList(
+	return Arrays.asList(
       PropertyDefinition.builder(FindbugsConstants.EFFORT_PROPERTY)
         .defaultValue(FindbugsConstants.EFFORT_DEFAULT_VALUE)
         .category(Java.KEY)
@@ -578,27 +577,15 @@ public class FindbugsConfiguration implements Startable {
         .name("Only Analyze")
         .description("To analyze only the given files (in FQCN, comma separted) / package patterns")
         .type(PropertyType.STRING)
-        .build()      
-      );
-    
-    if (context.getSonarQubeVersion().isGreaterThanOrEqual(Version.create(9, 8))) {
-      // The sonar-java plugin API only has the methods to get the test binaries/classpath starting with SonarQube 9.8
-      // For clarity we hide the property in earlier versions because it would have no effect (tests are not analyzed)
-      properties = new ArrayList<>(properties);
-      properties.add(
-          PropertyDefinition.builder(FindbugsConstants.ANALYZE_TESTS)
-          .defaultValue(Boolean.toString(FindbugsConstants.ANALYZE_TESTS_VALUE))
-          .category(Java.KEY)
-          .subCategory(subCategory)
-          .name("Analyze tests")
-          .description("Look for bugs in the project test code")
-          .onQualifiers(Qualifiers.PROJECT)
-          .type(PropertyType.BOOLEAN)
-          .build()
-          );
-    }
-    
-    return properties;
+        .build(),
+        PropertyDefinition.builder(FindbugsConstants.ANALYZE_TESTS)
+        .defaultValue(Boolean.toString(FindbugsConstants.ANALYZE_TESTS_VALUE))
+        .category(Java.KEY)
+        .subCategory(subCategory)
+        .name("Analyze tests")
+        .description("Look for bugs in the project test code")
+        .onQualifiers(Qualifiers.PROJECT)
+        .type(PropertyType.BOOLEAN)
+        .build());
   }
-
 }

--- a/src/main/java/org/sonar/plugins/findbugs/FindbugsPlugin.java
+++ b/src/main/java/org/sonar/plugins/findbugs/FindbugsPlugin.java
@@ -21,9 +21,11 @@ package org.sonar.plugins.findbugs;
 
 import java.util.Arrays;
 import java.util.stream.Collectors;
+
 import org.sonar.api.Plugin;
 import org.sonar.api.batch.fs.FilePredicate;
 import org.sonar.api.batch.fs.FilePredicates;
+import org.sonar.plugins.findbugs.classpath.DefaultClasspathLocator;
 import org.sonar.plugins.findbugs.language.Jsp;
 import org.sonar.plugins.findbugs.language.scala.Scala;
 import org.sonar.plugins.findbugs.profiles.FindbugsContribProfile;
@@ -87,6 +89,7 @@ public class FindbugsPlugin implements Plugin {
             FindSecurityBugsRulesDefinition.class,
             FindSecurityBugsJspRulesDefinition.class,
             FindSecurityBugsScalaRulesDefinition.class,
+            DefaultClasspathLocator.class,
             ByteCodeResourceLocator.class));
   }
 }

--- a/src/main/java/org/sonar/plugins/findbugs/FindbugsSensor.java
+++ b/src/main/java/org/sonar/plugins/findbugs/FindbugsSensor.java
@@ -40,6 +40,7 @@ import org.sonar.api.batch.sensor.SensorDescriptor;
 import org.sonar.api.batch.sensor.error.NewAnalysisError;
 import org.sonar.api.batch.sensor.issue.NewIssue;
 import org.sonar.api.batch.sensor.issue.NewIssueLocation;
+import org.sonar.plugins.findbugs.classpath.ClasspathLocator;
 import org.sonar.plugins.findbugs.language.Jsp;
 import org.sonar.plugins.findbugs.language.scala.Scala;
 import org.sonar.plugins.findbugs.resource.ByteCodeResourceLocator;
@@ -50,7 +51,6 @@ import org.sonar.plugins.findbugs.rules.FindSecurityBugsJspRulesDefinition;
 import org.sonar.plugins.findbugs.rules.FindSecurityBugsRulesDefinition;
 import org.sonar.plugins.findbugs.rules.FindSecurityBugsScalaRulesDefinition;
 import org.sonar.plugins.findbugs.rules.FindbugsRulesDefinition;
-import org.sonar.plugins.java.api.JavaResourceLocator;
 
 import edu.umd.cs.findbugs.AnalysisError;
 
@@ -67,7 +67,7 @@ public class FindbugsSensor implements Sensor {
 
   private ActiveRules activeRules;
   private FindbugsExecutor executor;
-  private final JavaResourceLocator javaResourceLocator;
+  private final ClasspathLocator classpathLocator;
   private final ByteCodeResourceLocator byteCodeResourceLocator;
   private final FileSystem fs;
   private final SensorContext sensorContext;
@@ -75,11 +75,11 @@ public class FindbugsSensor implements Sensor {
   protected PrintWriter classMappingWriter;
 
   public FindbugsSensor(ActiveRules activeRules, SensorContext sensorContext,
-                        FindbugsExecutor executor, JavaResourceLocator javaResourceLocator, FileSystem fs, ByteCodeResourceLocator byteCodeResourceLocator) {
+                        FindbugsExecutor executor, ClasspathLocator classpathLocator, FileSystem fs, ByteCodeResourceLocator byteCodeResourceLocator) {
     this.activeRules = activeRules;
     this.sensorContext = sensorContext;
     this.executor = executor;
-    this.javaResourceLocator = javaResourceLocator;
+    this.classpathLocator = classpathLocator;
     this.byteCodeResourceLocator = byteCodeResourceLocator;
     this.fs = fs;
     registerRepositories(REPOS);
@@ -292,9 +292,9 @@ public class FindbugsSensor implements Sensor {
    * @return File handle of the original class file analyzed
    */
   private File findOriginalClassForBug(ReportedBug bugInstance) {
-    String sourceFile = byteCodeResourceLocator.findClassFileByClassName(bugInstance.getClassName(), javaResourceLocator);
+    String sourceFile = byteCodeResourceLocator.findClassFileByClassName(bugInstance.getClassName(), classpathLocator);
     if (sourceFile == null) {
-      sourceFile = byteCodeResourceLocator.findClassFileByClassName(bugInstance.getClassFile(), javaResourceLocator);
+      sourceFile = byteCodeResourceLocator.findClassFileByClassName(bugInstance.getClassFile(), classpathLocator);
     }
     
     if (sourceFile == null) {

--- a/src/main/java/org/sonar/plugins/findbugs/classpath/ClasspathLocator.java
+++ b/src/main/java/org/sonar/plugins/findbugs/classpath/ClasspathLocator.java
@@ -35,4 +35,6 @@ public interface ClasspathLocator {
   Collection<File> testBinaryDirs();
 
   Collection<File> testClasspath();
+  
+  Collection<File> classFilesToAnalyze();
 }

--- a/src/main/java/org/sonar/plugins/findbugs/resource/ByteCodeResourceLocator.java
+++ b/src/main/java/org/sonar/plugins/findbugs/resource/ByteCodeResourceLocator.java
@@ -36,7 +36,7 @@ import org.slf4j.LoggerFactory;
 import org.sonar.api.batch.ScannerSide;
 import org.sonar.api.batch.fs.FileSystem;
 import org.sonar.api.batch.fs.InputFile;
-import org.sonar.plugins.java.api.JavaResourceLocator;
+import org.sonar.plugins.findbugs.classpath.ClasspathLocator;
 
 /**
  * Utility method related to mapped class name to various resources and extracting addition information.
@@ -61,13 +61,13 @@ public class ByteCodeResourceLocator {
     /**
      * findSourceFileKeyByClassName() is broken in SonarQube 6.3.1.. This method is fixing it.
      * @param className The name of class to find the source file
-     * @param javaResourceLocator The {@link JavaResourceLocator} to find resource by classname
+     * @param classpathLocator The {@link ClasspathLocator} to find resource by classname
      * @return String filepath
      */
-    public String findClassFileByClassName(String className, JavaResourceLocator javaResourceLocator) {
+    public String findClassFileByClassName(String className, ClasspathLocator classpathLocator) {
         String fileName = className.replace(".","/")+".class";
 
-        Collection<File> classPathEntries = javaResourceLocator.classpath();
+        Collection<File> classPathEntries = classpathLocator.classpath();
         for(File classPathEntry : classPathEntries) {
             if(classPathEntry.isDirectory()) { //Skip jars in the classpath
 

--- a/src/test/java/org/sonar/plugins/findbugs/FindbugsConfigurationTest.java
+++ b/src/test/java/org/sonar/plugins/findbugs/FindbugsConfigurationTest.java
@@ -52,7 +52,6 @@ import org.sonar.api.testfixtures.log.LogTesterJUnit5;
 import org.sonar.plugins.findbugs.classpath.ClasspathLocator;
 import org.sonar.plugins.findbugs.configuration.SimpleConfiguration;
 import org.sonar.plugins.findbugs.rule.FakeActiveRules;
-import org.sonar.plugins.java.api.JavaResourceLocator;
 
 import com.google.common.collect.ImmutableList;
 
@@ -74,7 +73,6 @@ class FindbugsConfigurationTest {
   private File workDir;
   private ActiveRules activeRules;
   private FindbugsConfiguration conf;
-  private JavaResourceLocator javaResourceLocator;
   private ClasspathLocator classpathLocator;
 
   @BeforeEach
@@ -92,9 +90,8 @@ class FindbugsConfigurationTest {
     activeRules = FakeActiveRules.createWithOnlyFindbugsRules();
 
     configuration = new SimpleConfiguration();
-    javaResourceLocator = mock(JavaResourceLocator.class);
     classpathLocator = mock(ClasspathLocator.class);
-    conf = new FindbugsConfiguration(fs, configuration, activeRules, javaResourceLocator);
+    conf = new FindbugsConfiguration(fs, configuration, activeRules, classpathLocator);
   }
 
   @Test
@@ -140,7 +137,7 @@ class FindbugsConfigurationTest {
   @Test
   void should_set_class_files() throws IOException {
     File file = new File(temp, "MyClass.class");
-    when(javaResourceLocator.classFilesToAnalyze()).thenReturn(ImmutableList.of(file));
+    when(classpathLocator.classFilesToAnalyze()).thenReturn(ImmutableList.of(file));
     try (Project findbugsProject = new Project()) {
       conf.initializeFindbugsProject(findbugsProject);
       
@@ -152,7 +149,7 @@ class FindbugsConfigurationTest {
   @Test
   void should_set_class_path() throws IOException {
     File classpath = new File(temp, "classpath");
-    when(javaResourceLocator.classpath()).thenReturn(ImmutableList.of(classpath));
+    when(classpathLocator.classpath()).thenReturn(ImmutableList.of(classpath));
     try (Project findbugsProject = new Project()) {
       conf.initializeFindbugsProject(findbugsProject);
 
@@ -396,7 +393,7 @@ class FindbugsConfigurationTest {
     List<File> classpathFiles = Arrays.asList(jarFile, classesFolder, jspServletFolder, moduleInfoFile);
     List<File> testClasspathFiles = Arrays.asList(testJarFile, testOtherJarFile);
     
-    when(javaResourceLocator.classpath()).thenReturn(classpathFiles);
+    when(classpathLocator.classpath()).thenReturn(classpathFiles);
     when(classpathLocator.testClasspath()).thenReturn(testClasspathFiles);
     
     if (withSq98Api) {
@@ -437,8 +434,8 @@ class FindbugsConfigurationTest {
   
   @Test
   void buildMissingCompiledCodeException() {
-    when(javaResourceLocator.classFilesToAnalyze()).thenReturn(Collections.emptyList());
-    when(javaResourceLocator.classpath()).thenReturn(Collections.emptyList());
+    when(classpathLocator.classFilesToAnalyze()).thenReturn(Collections.emptyList());
+    when(classpathLocator.classpath()).thenReturn(Collections.emptyList());
     
     assertThat(conf.buildMissingCompiledCodeException().getMessage()).contains("Property sonar.java.binaries was not set");
     assertThat(conf.buildMissingCompiledCodeException().getMessage()).contains("Sonar JavaResourceLocator.classpath was empty");
@@ -448,8 +445,8 @@ class FindbugsConfigurationTest {
     
     assertThat(conf.buildMissingCompiledCodeException().getMessage()).contains("sonar.java.binaries was set to");
     
-    when(javaResourceLocator.classFilesToAnalyze()).thenReturn(Collections.singletonList(baseDir));
-    when(javaResourceLocator.classpath()).thenReturn(Collections.singletonList(baseDir));
+    when(classpathLocator.classFilesToAnalyze()).thenReturn(Collections.singletonList(baseDir));
+    when(classpathLocator.classpath()).thenReturn(Collections.singletonList(baseDir));
     
     assertThat(conf.buildMissingCompiledCodeException().getMessage()).doesNotContain("Sonar JavaResourceLocator.classpath was empty");
     assertThat(conf.buildMissingCompiledCodeException().getMessage()).doesNotContain("Sonar JavaResourceLocator.classFilesToAnalyze was empty");

--- a/src/test/java/org/sonar/plugins/findbugs/FindbugsPluginTest.java
+++ b/src/test/java/org/sonar/plugins/findbugs/FindbugsPluginTest.java
@@ -19,24 +19,23 @@
  */
 package org.sonar.plugins.findbugs;
 
-import org.sonar.api.Plugin;
-import org.sonar.api.SonarRuntime;
-import org.sonar.api.utils.Version;
-
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
+import org.sonar.api.Plugin;
+import org.sonar.api.SonarRuntime;
+import org.sonar.api.utils.Version;
 
 class FindbugsPluginTest {
 
   @ParameterizedTest
   @CsvSource({
-    "9.7,24",
+    "9.7,25",
     // We expect one more extension (the "sonar.findbugs.analyzeTests" property) when the version is >= 9.8
-    "9.8,25"
+    "9.8,26"
   })
   void testGetExtensions(String version, int expectedExtensionsCount) {
 

--- a/src/test/java/org/sonar/plugins/findbugs/FindbugsPluginTest.java
+++ b/src/test/java/org/sonar/plugins/findbugs/FindbugsPluginTest.java
@@ -21,31 +21,21 @@ package org.sonar.plugins.findbugs;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.api.Test;
 import org.sonar.api.Plugin;
 import org.sonar.api.SonarRuntime;
-import org.sonar.api.utils.Version;
 
 class FindbugsPluginTest {
 
-  @ParameterizedTest
-  @CsvSource({
-    "9.7,25",
-    // We expect one more extension (the "sonar.findbugs.analyzeTests" property) when the version is >= 9.8
-    "9.8,26"
-  })
-  void testGetExtensions(String version, int expectedExtensionsCount) {
-
+  @Test
+  void testGetExtensions() {
     SonarRuntime runtime = mock(SonarRuntime.class);
-    when(runtime.getApiVersion()).thenReturn(Version.parse(version));
     Plugin.Context ctx = new Plugin.Context(runtime);
 
     FindbugsPlugin plugin = new FindbugsPlugin();
     plugin.define(ctx);
 
-    assertEquals(expectedExtensionsCount, ctx.getExtensions().size(), "extensions count");
+    assertEquals(26, ctx.getExtensions().size(), "extensions count");
   }
 }

--- a/src/test/java/org/sonar/plugins/findbugs/FindbugsSensorTest.java
+++ b/src/test/java/org/sonar/plugins/findbugs/FindbugsSensorTest.java
@@ -19,13 +19,14 @@
  */
 package org.sonar.plugins.findbugs;
 
-import com.google.common.collect.Lists;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
-import edu.umd.cs.findbugs.AnalysisError;
-import edu.umd.cs.findbugs.BugInstance;
-import edu.umd.cs.findbugs.ClassAnnotation;
-import edu.umd.cs.findbugs.MethodAnnotation;
-import edu.umd.cs.findbugs.SourceLineAnnotation;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -52,20 +53,19 @@ import org.sonar.api.batch.sensor.error.NewAnalysisError;
 import org.sonar.api.batch.sensor.issue.NewIssue;
 import org.sonar.api.batch.sensor.issue.NewIssueLocation;
 import org.sonar.api.rule.RuleKey;
+import org.sonar.plugins.findbugs.classpath.ClasspathLocator;
 import org.sonar.plugins.findbugs.resource.ByteCodeResourceLocator;
 import org.sonar.plugins.findbugs.resource.SmapParser.FileInfo;
 import org.sonar.plugins.findbugs.resource.SmapParser.SmapLocation;
 import org.sonar.plugins.findbugs.rule.FakeActiveRules;
-import org.sonar.plugins.java.api.JavaResourceLocator;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import com.google.common.collect.Lists;
+
+import edu.umd.cs.findbugs.AnalysisError;
+import edu.umd.cs.findbugs.BugInstance;
+import edu.umd.cs.findbugs.ClassAnnotation;
+import edu.umd.cs.findbugs.MethodAnnotation;
+import edu.umd.cs.findbugs.SourceLineAnnotation;
 
 class FindbugsSensorTest extends FindbugsTests {
   @TempDir
@@ -76,14 +76,14 @@ class FindbugsSensorTest extends FindbugsTests {
   private MutablePicoContainer pico;
   private SensorContext sensorContext;
   private FindbugsExecutor executor;
-  private JavaResourceLocator javaResourceLocator;
+  private ClasspathLocator classpathLocator;
 
   @BeforeEach
   public void setUp() throws IOException {
     sensorContext = mock(SensorContext.class);
     byteCodeResourceLocator = mock(ByteCodeResourceLocator.class);
     executor = mock(FindbugsExecutor.class);
-    javaResourceLocator = mockJavaResourceLocator();
+    classpathLocator = mock(ClasspathLocator.class);
     
     File baseDir = new File(temp, "findbugs");
 
@@ -128,14 +128,7 @@ class FindbugsSensorTest extends FindbugsTests {
     when(sensorContext.newAnalysisError()).thenReturn(newAnalysisError);
 
     pico.addComponent(executor);
-    pico.addComponent(javaResourceLocator);
-  }
-
-  private static JavaResourceLocator mockJavaResourceLocator() {
-    JavaResourceLocator javaResourceLocator = mock(JavaResourceLocator.class);
-    InputFile resource = mock(InputFile.class);
-    when(javaResourceLocator.findResourceByClassName(anyString())).thenReturn(resource);
-    return javaResourceLocator;
+    pico.addComponent(classpathLocator);
   }
 
   @Test
@@ -143,8 +136,6 @@ class FindbugsSensorTest extends FindbugsTests {
 
     BugInstance bugInstance = getBugInstance("AM_CREATES_EMPTY_ZIP_FILE_ENTRY", 6, true);
     when(executor.execute(false, false)).thenReturn(new AnalysisResult(bugInstance));
-    JavaResourceLocator javaResourceLocator = mockJavaResourceLocator();
-    when(javaResourceLocator.classFilesToAnalyze()).thenReturn(Lists.newArrayList(new File("file")));
 
     pico.addComponent(FakeActiveRules.createWithOnlyFindbugsRules());
     FindbugsSensor sensor = pico.getComponent(FindbugsSensor.class);
@@ -160,9 +151,8 @@ class FindbugsSensorTest extends FindbugsTests {
     BugInstance bugInstance = getBugInstance("AM_CREATES_EMPTY_ZIP_FILE_ENTRY", 13, false);
     when(executor.execute(false, false)).thenReturn(new AnalysisResult(bugInstance));
 
-    when(javaResourceLocator.findResourceByClassName(anyString())).thenReturn(null);
     when(fs.inputFiles(any(FilePredicate.class))).thenReturn(new ArrayList<InputFile>());
-    when(javaResourceLocator.classFilesToAnalyze()).thenReturn(Lists.newArrayList(new File("file")));
+    when(classpathLocator.classFilesToAnalyze()).thenReturn(Lists.newArrayList(new File("file")));
 
     pico.addComponent(FakeActiveRules.createWithOnlyFindbugsRules());
     FindbugsSensor analyser = pico.getComponent(FindbugsSensor.class);
@@ -178,8 +168,7 @@ class FindbugsSensorTest extends FindbugsTests {
 
     BugInstance bugInstance = getBugInstance("ISB_INEFFICIENT_STRING_BUFFERING", 49, true);
     when(executor.execute(true, false)).thenReturn(new AnalysisResult(bugInstance));
-    JavaResourceLocator javaResourceLocator = mockJavaResourceLocator();
-    when(javaResourceLocator.classFilesToAnalyze()).thenReturn(Lists.newArrayList(new File("file")));
+    when(classpathLocator.classFilesToAnalyze()).thenReturn(Lists.newArrayList(new File("file")));
 
     pico.addComponent(FakeActiveRules.createWithOnlyFbContribRules());
 
@@ -196,7 +185,7 @@ class FindbugsSensorTest extends FindbugsTests {
     BugInstance bugInstance = getBugInstance("PREDICTABLE_RANDOM", 0, true);
     when(executor.execute(false, true)).thenReturn(new AnalysisResult(bugInstance));
 
-    when(javaResourceLocator.classFilesToAnalyze()).thenReturn(Lists.newArrayList(new File("file")));
+    when(classpathLocator.classFilesToAnalyze()).thenReturn(Lists.newArrayList(new File("file")));
 
     pico.addComponent(FakeActiveRules.createWithOnlyFindSecBugsRules());
 
@@ -213,7 +202,7 @@ class FindbugsSensorTest extends FindbugsTests {
     BugInstance bugInstance = getBugInstance("THIS_RULE_DOES_NOT_EXIST", 107, true);
     when(executor.execute(false, false)).thenReturn(new AnalysisResult(bugInstance));
 
-    when(javaResourceLocator.classFilesToAnalyze()).thenReturn(Lists.newArrayList(new File("file")));
+    when(classpathLocator.classFilesToAnalyze()).thenReturn(Lists.newArrayList(new File("file")));
 
     pico.addComponent(FakeActiveRules.createWithOnlyFindbugsRules());
 
@@ -227,7 +216,7 @@ class FindbugsSensorTest extends FindbugsTests {
   @Test
   void should_not_execute_findbugs_if_no_active() throws Exception {
 
-    when(javaResourceLocator.classFilesToAnalyze()).thenReturn(Lists.newArrayList(new File("file")));
+    when(classpathLocator.classFilesToAnalyze()).thenReturn(Lists.newArrayList(new File("file")));
 
     pico.addComponent(FakeActiveRules.createWithNoRules());
 
@@ -248,7 +237,7 @@ class FindbugsSensorTest extends FindbugsTests {
     TreeSet<String> languages = new TreeSet<>(Arrays.asList("java", "xml"));
     when(fs.languages()).thenReturn(languages);
 
-    when(javaResourceLocator.classFilesToAnalyze()).thenReturn(Lists.newArrayList(new File("file")));
+    when(classpathLocator.classFilesToAnalyze()).thenReturn(Lists.newArrayList(new File("file")));
 
     pico.addComponent(FakeActiveRules.createWithOnlyFindSecBugsJspRules());
 
@@ -267,7 +256,7 @@ class FindbugsSensorTest extends FindbugsTests {
     TreeSet<String> languages = new TreeSet<>(Arrays.asList("java", "xml", "jsp"));
     when(fs.languages()).thenReturn(languages);
     
-    when(javaResourceLocator.classFilesToAnalyze()).thenReturn(Lists.newArrayList(new File("file")));
+    when(classpathLocator.classFilesToAnalyze()).thenReturn(Lists.newArrayList(new File("file")));
     when(executor.execute(false, true)).thenReturn(new AnalysisResult());
 
     pico.addComponent(FakeActiveRules.createWithOnlyFindSecBugsJspRules());
@@ -283,11 +272,10 @@ class FindbugsSensorTest extends FindbugsTests {
   void should_execute_findbugs_with_missing_smap_and_source() throws Exception {
     BugInstance bugInstance = getBugInstance("AM_CREATES_EMPTY_ZIP_FILE_ENTRY", 6, true);
     when(executor.execute(false, false)).thenReturn(new AnalysisResult(bugInstance));
-    JavaResourceLocator javaResourceLocator = mockJavaResourceLocator();
-    when(javaResourceLocator.classFilesToAnalyze()).thenReturn(Lists.newArrayList(new File("file")));
+    when(classpathLocator.classFilesToAnalyze()).thenReturn(Lists.newArrayList(new File("file")));
     
     // return a class file that does not have SMAP (doesn't exist actually)
-    when(byteCodeResourceLocator.findClassFileByClassName("org.sonar.commons.ZipUtils", this.javaResourceLocator)).thenReturn("");
+    when(byteCodeResourceLocator.findClassFileByClassName("org.sonar.commons.ZipUtils", this.classpathLocator)).thenReturn("");
     // don't return a source file: the input file is not in the file system even if SpotBugs found an issue in a class file
     when(byteCodeResourceLocator.findSourceFile("org/sonar/commons/org/sonar/commons/ZipUtils.java", fs)).thenReturn(null);
     
@@ -303,12 +291,11 @@ class FindbugsSensorTest extends FindbugsTests {
   void should_execute_findbugs_with_smap() throws Exception {
     BugInstance bugInstance = getBugInstance("AM_CREATES_EMPTY_ZIP_FILE_ENTRY", 6, true);
     when(executor.execute(false, false)).thenReturn(new AnalysisResult(bugInstance));
-    JavaResourceLocator javaResourceLocator = mockJavaResourceLocator();
-    when(javaResourceLocator.classFilesToAnalyze()).thenReturn(Lists.newArrayList(new File("file")));
+    when(classpathLocator.classFilesToAnalyze()).thenReturn(Lists.newArrayList(new File("file")));
     
     String classFileName = "org/sonar/commons/ZipUtils.class";
     
-    when(byteCodeResourceLocator.findClassFileByClassName("org.sonar.commons.ZipUtils", this.javaResourceLocator)).thenReturn(classFileName);
+    when(byteCodeResourceLocator.findClassFileByClassName("org.sonar.commons.ZipUtils", this.classpathLocator)).thenReturn(classFileName);
     
     // Return a valid SMAP location
     FileInfo fileInfo = new FileInfo("ZipUtils", "org/sonar/commons/org/sonar/commons/ZipUtils.java");

--- a/src/test/java/org/sonar/plugins/findbugs/it/FindSecBugsJspIT.java
+++ b/src/test/java/org/sonar/plugins/findbugs/it/FindSecBugsJspIT.java
@@ -2,15 +2,15 @@ package org.sonar.plugins.findbugs.it;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import org.junit.jupiter.api.Test;
-import org.sonarqube.ws.Issues.Issue;
-import org.sonarqube.ws.client.issues.IssuesService;
-
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.sonarqube.ws.Issues.Issue;
+import org.sonarqube.ws.client.issues.IssuesService;
 
 import com.sonar.orchestrator.build.MavenBuild;
 import com.sonar.orchestrator.junit5.OrchestratorExtension;
@@ -34,7 +34,6 @@ class FindSecBugsJspIT {
       .setPom(FindbugsTestSuite.projectPom("jspc-sling"))
       .setProperty("sonar.dynamicAnalysis", "false")
       .setProperty("sonar.findbugs.confidenceLevel", "low")
-      .setProperty("sonar.plugins.downloadOnlyRequired", "false")
       .setGoals("clean package sonar:sonar");
     orchestrator.executeBuild(build);
 
@@ -63,7 +62,6 @@ class FindSecBugsJspIT {
       .setPom(FindbugsTestSuite.projectPom("jspc-jetty"))
       .setProperty("sonar.dynamicAnalysis", "false")
       .setProperty("sonar.findbugs.confidenceLevel", "low")
-      .setProperty("sonar.plugins.downloadOnlyRequired", "false")
       .setGoals("clean package sonar:sonar");
     orchestrator.executeBuild(build);
 

--- a/src/test/java/org/sonar/plugins/findbugs/it/FindbugsTestSuite.java
+++ b/src/test/java/org/sonar/plugins/findbugs/it/FindbugsTestSuite.java
@@ -19,11 +19,12 @@
  */
 package org.sonar.plugins.findbugs.it;
 
-import com.sonar.orchestrator.junit5.OrchestratorExtension;
-import com.sonar.orchestrator.junit5.OrchestratorExtensionBuilder;
-import com.sonar.orchestrator.locator.FileLocation;
-import com.sonar.orchestrator.locator.Location;
-import com.sonar.orchestrator.locator.MavenLocation;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.file.FileSystems;
+import java.nio.file.Files;
 
 import org.sonarqube.ws.client.HttpConnector;
 import org.sonarqube.ws.client.issues.IssuesService;
@@ -33,12 +34,11 @@ import org.sonarqube.ws.client.projects.ProjectsService;
 import org.sonarqube.ws.client.qualityprofiles.AddProjectRequest;
 import org.sonarqube.ws.client.qualityprofiles.QualityprofilesService;
 
-import java.io.File;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.io.OutputStream;
-import java.nio.file.FileSystems;
-import java.nio.file.Files;
+import com.sonar.orchestrator.junit5.OrchestratorExtension;
+import com.sonar.orchestrator.junit5.OrchestratorExtensionBuilder;
+import com.sonar.orchestrator.locator.FileLocation;
+import com.sonar.orchestrator.locator.Location;
+import com.sonar.orchestrator.locator.MavenLocation;
 
 @IntegrationTest
 public class FindbugsTestSuite {
@@ -60,7 +60,6 @@ public class FindbugsTestSuite {
       .useDefaultAdminCredentialsForBuilds(true)
       .setSonarVersion("LATEST_RELEASE[" + sonarVersion + "]")
       .setOrchestratorProperty("orchestrator.artifactory.url", "https://repo1.maven.org/maven2")
-      .setServerProperty("sonar.plugins.downloadOnlyRequired", "false")
       .restoreProfileAtStartup(FileLocation.ofClasspath("/it/profiles/empty-backup.xml"))
       .restoreProfileAtStartup(FileLocation.ofClasspath("/it/profiles/findbugs-backup.xml"))
       .restoreProfileAtStartup(FileLocation.ofClasspath("/it/profiles/fbcontrib-backup.xml"));

--- a/src/test/java/org/sonar/plugins/findbugs/it/ScalaIT.java
+++ b/src/test/java/org/sonar/plugins/findbugs/it/ScalaIT.java
@@ -19,14 +19,14 @@ package org.sonar.plugins.findbugs.it;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.List;
+
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.sonar.plugins.findbugs.profiles.FindbugsSecurityScalaProfile;
 import org.sonarqube.ws.Issues.Issue;
 import org.sonarqube.ws.client.issues.IssuesService;
-
-import java.util.List;
 
 import com.sonar.orchestrator.build.MavenBuild;
 import com.sonar.orchestrator.junit5.OrchestratorExtension;
@@ -54,7 +54,6 @@ class ScalaIT {
       .setPom(FindbugsTestSuite.projectPom("scala"))
       .setProperty("sonar.dynamicAnalysis", "false")
       .setProperty("sonar.findbugs.confidenceLevel", "low")
-      .setProperty("sonar.plugins.downloadOnlyRequired", "false")
       //.setProperty("sonar.sources", "src/main/scala")
       //.setProperty("sonar.java.binaries", "target/classes")
       .setGoals("clean package sonar:sonar");

--- a/src/test/java/org/sonar/plugins/findbugs/resource/ByteCodeResourceLocatorTest.java
+++ b/src/test/java/org/sonar/plugins/findbugs/resource/ByteCodeResourceLocatorTest.java
@@ -1,13 +1,12 @@
 package org.sonar.plugins.findbugs.resource;
 
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.io.TempDir;
-import org.sonar.api.batch.fs.FilePredicate;
-import org.sonar.api.batch.fs.FilePredicates;
-import org.sonar.api.batch.fs.FileSystem;
-import org.sonar.api.batch.fs.InputFile;
-import org.sonar.plugins.java.api.JavaResourceLocator;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import java.io.File;
 import java.io.IOException;
@@ -16,16 +15,16 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
 
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.sonar.api.batch.fs.FilePredicate;
+import org.sonar.api.batch.fs.FilePredicates;
+import org.sonar.api.batch.fs.FileSystem;
+import org.sonar.api.batch.fs.InputFile;
+import org.sonar.plugins.findbugs.classpath.ClasspathLocator;
+
 import com.google.common.collect.ImmutableList;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-
-import static org.assertj.core.api.Assertions.assertThat;
 
 class ByteCodeResourceLocatorTest {
 
@@ -128,15 +127,15 @@ class ByteCodeResourceLocatorTest {
   
   @Test
   void findClassFileByClassName() throws IOException {
-    JavaResourceLocator javaResourceLocator = mock(JavaResourceLocator.class);
+    ClasspathLocator classpathLocator = mock(ClasspathLocator.class);
     
     Path folderPath = Files.createDirectories(temp.toPath().resolve("foo").resolve("bar"));
     Path testFolderPath = Files.createDirectories(temp.toPath().resolve("test").resolve("123"));
     Path filePath = Files.createFile(folderPath.resolve("Test.class"));
     
-    when(javaResourceLocator.classpath()).thenReturn(Arrays.asList(testFolderPath.toFile(), filePath.toFile(), temp));
+    when(classpathLocator.classpath()).thenReturn(Arrays.asList(testFolderPath.toFile(), filePath.toFile(), temp));
 
     ByteCodeResourceLocator locator = new ByteCodeResourceLocator();
-    assertThat(locator.findClassFileByClassName("foo.bar.Test", javaResourceLocator)).isNotNull();
+    assertThat(locator.findClassFileByClassName("foo.bar.Test", classpathLocator)).isNotNull();
   }
 }


### PR DESCRIPTION
Since Sonarqube 10.6 the plugin can no longer reliably depend on the built-in sonar-java plugin.
We are using it to get the project classpath and list the .class files we want to analyze.

Instead bundle (shade) the plugin and the other dependencies so we can use it.
Since we are not running the sonar-java plugin and since `classFilesToAnalyze()` was populated as a side effect of sonar-java running, we need to get the class files ourselves. This will change the behaviour because now we get all the class files from the binary dirs, so we might analyze files that were previously marked as excluded.