### PR TITLE
Ignore .kts file when looking for sources

### DIFF
--- a/src/main/java/org/sonar/plugins/findbugs/FindbugsConfiguration.java
+++ b/src/main/java/org/sonar/plugins/findbugs/FindbugsConfiguration.java
@@ -242,6 +242,8 @@ public class FindbugsConfiguration implements Startable {
             pred.and(
                     pred.hasType(Type.MAIN),
                     pred.or(FindbugsPlugin.getSupportedLanguagesFilePredicate(pred)),
+                    // .kts files are assumed to be executed by kotlin support, so we're not expecting a .class file
+                    pred.not(pred.hasExtension(".kts")),
                     //package-info.java will not generate any class files.
                     //See: https://github.com/SonarQubeCommunity/sonar-findbugs/issues/36
                     pred.not(pred.matchesPathPattern("**/package-info.java")),


### PR DESCRIPTION
kts files are typically not compiled into a .class file, ignore them when looking for uncompiled projects

This should fix #1037 