### PR TITLE
Exclude deprecated rules from pre-defined profiles

### DIFF
--- a/generate_profiles/BuildXmlFiles.groovy
+++ b/generate_profiles/BuildXmlFiles.groovy
@@ -279,8 +279,11 @@ def getAllPatternsFromPlugin(Plugin plugin) {
     patternsXml.BugPattern.each { pattern ->
 
         category = getFindBugsCategory([plugin], pattern.attribute("type"))
+        deprecated = deprecated = (pattern.attribute("deprecated") == "true")
+
 
         if (category == "EXPERIMENTAL" || category == "NOISE") return;
+        if (deprecated) return;
         //if (category == "MT_CORRECTNESS") category = "MULTI-THREADING";
 
         patterns << pattern.attribute("type")

--- a/src/main/java/org/sonar/plugins/findbugs/rules/FindbugsRulesDefinition.java
+++ b/src/main/java/org/sonar/plugins/findbugs/rules/FindbugsRulesDefinition.java
@@ -29,6 +29,7 @@ public final class FindbugsRulesDefinition implements RulesDefinition {
   public static final String REPOSITORY_KEY = "findbugs";
   public static final String REPOSITORY_NAME = "FindBugs";
   public static final int RULE_COUNT = 483;
+  public static final int DEPRECATED_RULE_COUNT = 4;
   public static final int DEACTIVED_RULE_COUNT = 6;
 
   @Override

--- a/src/main/resources/org/sonar/plugins/findbugs/profile-findbugs-and-fb-contrib.xml
+++ b/src/main/resources/org/sonar/plugins/findbugs/profile-findbugs-and-fb-contrib.xml
@@ -408,9 +408,6 @@
     <Bug pattern='TLW_TWO_LOCK_WAIT' />
   </Match>
   <Match>
-    <Bug pattern='TLW_TWO_LOCK_NOTIFY' />
-  </Match>
-  <Match>
     <Bug pattern='UW_UNCOND_WAIT' />
   </Match>
   <Match>
@@ -954,9 +951,6 @@
     <Bug pattern='BIT_IOR' />
   </Match>
   <Match>
-    <Bug pattern='LI_LAZY_INIT_INSTANCE' />
-  </Match>
-  <Match>
     <Bug pattern='LI_LAZY_INIT_STATIC' />
   </Match>
   <Match>
@@ -1027,9 +1021,6 @@
   </Match>
   <Match>
     <Bug pattern='BOA_BADLY_OVERRIDDEN_ADAPTER' />
-  </Match>
-  <Match>
-    <Bug pattern='BRSA_BAD_RESULTSET_ACCESS' />
   </Match>
   <Match>
     <Bug pattern='SQL_BAD_RESULTSET_ACCESS' />
@@ -1168,9 +1159,6 @@
   </Match>
   <Match>
     <Bug pattern='NP_NULL_INSTANCEOF' />
-  </Match>
-  <Match>
-    <Bug pattern='BC_NULL_INSTANCEOF' />
   </Match>
   <Match>
     <Bug pattern='BC_IMPOSSIBLE_INSTANCEOF' />

--- a/src/main/resources/org/sonar/plugins/findbugs/profile-findbugs-only.xml
+++ b/src/main/resources/org/sonar/plugins/findbugs/profile-findbugs-only.xml
@@ -408,9 +408,6 @@
     <Bug pattern='TLW_TWO_LOCK_WAIT' />
   </Match>
   <Match>
-    <Bug pattern='TLW_TWO_LOCK_NOTIFY' />
-  </Match>
-  <Match>
     <Bug pattern='UW_UNCOND_WAIT' />
   </Match>
   <Match>
@@ -954,9 +951,6 @@
     <Bug pattern='BIT_IOR' />
   </Match>
   <Match>
-    <Bug pattern='LI_LAZY_INIT_INSTANCE' />
-  </Match>
-  <Match>
     <Bug pattern='LI_LAZY_INIT_STATIC' />
   </Match>
   <Match>
@@ -1027,9 +1021,6 @@
   </Match>
   <Match>
     <Bug pattern='BOA_BADLY_OVERRIDDEN_ADAPTER' />
-  </Match>
-  <Match>
-    <Bug pattern='BRSA_BAD_RESULTSET_ACCESS' />
   </Match>
   <Match>
     <Bug pattern='SQL_BAD_RESULTSET_ACCESS' />
@@ -1168,9 +1159,6 @@
   </Match>
   <Match>
     <Bug pattern='NP_NULL_INSTANCEOF' />
-  </Match>
-  <Match>
-    <Bug pattern='BC_NULL_INSTANCEOF' />
   </Match>
   <Match>
     <Bug pattern='BC_IMPOSSIBLE_INSTANCEOF' />

--- a/src/test/java/org/sonar/plugins/findbugs/profiles/FindbugsContribProfileTest.java
+++ b/src/test/java/org/sonar/plugins/findbugs/profiles/FindbugsContribProfileTest.java
@@ -27,7 +27,7 @@ class FindbugsContribProfileTest {
     findbugsProfile.define(context);
     
     BuiltInQualityProfile profile = context.profile(Java.KEY, FindbugsContribProfile.FB_CONTRIB_PROFILE_NAME);
-    assertThat(profile.rules().stream().filter(r -> r.repoKey().equals(FindbugsRulesDefinition.REPOSITORY_KEY)).count()).isEqualTo(FindbugsRulesDefinition.RULE_COUNT);
+    assertThat(profile.rules().stream().filter(r -> r.repoKey().equals(FindbugsRulesDefinition.REPOSITORY_KEY)).count()).isEqualTo(FindbugsRulesDefinition.RULE_COUNT - FindbugsRulesDefinition.DEPRECATED_RULE_COUNT);
     assertThat(profile.rules().stream().filter(r -> r.repoKey().equals(FbContribRulesDefinition.REPOSITORY_KEY)).count()).isEqualTo(FbContribRulesDefinition.RULE_COUNT);
     assertThat(logTester.getLogs(Level.ERROR)).isEmpty();
 

--- a/src/test/java/org/sonar/plugins/findbugs/profiles/FindbugsProfileTest.java
+++ b/src/test/java/org/sonar/plugins/findbugs/profiles/FindbugsProfileTest.java
@@ -54,8 +54,8 @@ class FindbugsProfileTest {
     findbugsProfile.define(context);
     
     BuiltInQualityProfile profile = context.profile(Java.KEY, FindbugsProfile.FINDBUGS_PROFILE_NAME);
-    assertThat(profile.rules()).hasSize(FindbugsRulesDefinition.RULE_COUNT);
-    assertThat(profile.rules().stream().filter(r -> r.repoKey().equals(FindbugsRulesDefinition.REPOSITORY_KEY)).count()).isEqualTo(FindbugsRulesDefinition.RULE_COUNT);
+    assertThat(profile.rules()).hasSize(FindbugsRulesDefinition.RULE_COUNT - FindbugsRulesDefinition.DEPRECATED_RULE_COUNT);
+    assertThat(profile.rules().stream().filter(r -> r.repoKey().equals(FindbugsRulesDefinition.REPOSITORY_KEY)).count()).isEqualTo(FindbugsRulesDefinition.RULE_COUNT - FindbugsRulesDefinition.DEPRECATED_RULE_COUNT);
     assertThat(logTester.getLogs(Level.ERROR)).isEmpty();
 
     FindbugsProfileTest.assertHasOnlyRulesForLanguage(profile.rules(), Java.KEY);


### PR DESCRIPTION
Exclude deprecated rules from pre-defined profiles. The rules are still available, but should not be part of the built-in profiles.
For reference: https://github.com/spotbugs/sonar-findbugs/issues/1142
![image001](https://github.com/user-attachments/assets/456c7d1b-a076-4d57-96b2-838c9163b393)

