### PR TITLE
deps: revert to the plugin API 9.14.0.375 for SonarQube 9.9 compat.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,7 @@
     <surefire.version>3.5.2</surefire.version>
     <failsafe.version>3.5.2</failsafe.version>
     <sonar.server.version>9.9.7.96285</sonar.server.version>
-    <sonar-plugin-api.version>9.17.0.587</sonar-plugin-api.version>
+    <sonar-plugin-api.version>9.14.0.375</sonar-plugin-api.version>
     <sonar-java.version>8.9.0.37768</sonar-java.version>
     
     <sonar-orchestrator.version>5.1.0.2254</sonar-orchestrator.version>


### PR DESCRIPTION
Hello @hazendaz, even though the renovate PR might pass tests we must be careful when updating dependencies because we need compatibility with various versions of SonarQube.
This should fix #1183 
