### PR TITLE
[gha] Fix syntax for environment reference 

### DIFF
--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -26,12 +26,12 @@ jobs:
   build:
     # Forked repos do not have access to the Sonar account
     if: github.repository == 'spotbugs/sonar-findbugs'
-    environment: |
-        (github.event_name != 'pull_request_target' && 'internal') || (
+    environment: >
+        ${{ (github.event_name != 'pull_request_target' && 'internal') || (
         (github.event.pull_request.author_association == 'OWNER' || 
         github.event.pull_request.author_association == 'COLLABORATOR' || 
         github.event.pull_request.author_association == 'MEMBER') && 
-        'internal' || 'external')
+        'internal' || 'external') }}
     runs-on: ubuntu-latest
     env:
       # previous LTS version


### PR DESCRIPTION
Correctly use context to reference the environment determination code.