### PR TITLE
Update profiler to 3.3 and restore maven clean plugin 3.4.0 support

### DIFF
--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -3,6 +3,6 @@
     <extension>
       <groupId>fr.jcgay.maven</groupId>
       <artifactId>maven-profiler</artifactId>
-      <version>3.2</version>
+      <version>3.3</version>
     </extension>
 </extensions>

--- a/pom.xml
+++ b/pom.xml
@@ -310,6 +310,9 @@
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-clean-plugin</artifactId>
           <version>3.5.0</version>
+          <configuration>
+            <force>true</force>
+          </configuration>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
for maven clean, maven had a bug in 3.4.1 that blocked checkout folder on release from being deleted (any read only file).  Instead of fixing the issue, they added a flag so the world must fix it.