### PR TITLE
Update sb-contrib version info

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,4 +82,4 @@ Findbugs Plugin version|Embedded SpotBugs/Findbugs version|Embedded Findsecbugs 
 4.5.0                  | 4.9.3 (SpotBugs)                 | 1.14.0                     | 7.6.10 (sb-contrib)        |  17|9.9-25.5|8.0.1.36337
 4.5.1                  | 4.9.3 (SpotBugs)                 | 1.14.0                     | 7.6.10 (sb-contrib)        |  17|9.9~|8.0.1.36337
 4.5.2                  | 4.9.3 (SpotBugs)                 | 1.14.0                     | 7.6.10 (sb-contrib)        |  17|9.9~|8.0.1.36337
-4.5.3-SNAPSHOT         | 4.9.3 (SpotBugs)                 | 1.14.0                     | 7.6.11 (sb-contrib)        |  17|9.9~|8.0.1.36337
+4.5.3-SNAPSHOT         | 4.9.3 (SpotBugs)                 | 1.14.0                     | 7.6.12 (sb-contrib)        |  17|9.9~|8.0.1.36337

--- a/generate_profiles/BuildXmlFiles.groovy
+++ b/generate_profiles/BuildXmlFiles.groovy
@@ -9,13 +9,13 @@ import groovy.json.JsonSlurper;
 @Grapes([
 
     @Grab(group='com.github.spotbugs', module='spotbugs', version='4.9.3'),
-    @Grab(group='com.mebigfatguy.sb-contrib', module='sb-contrib', version='7.6.11'),
+    @Grab(group='com.mebigfatguy.sb-contrib', module='sb-contrib', version='7.6.12'),
     @Grab(group='com.h3xstream.findsecbugs' , module='findsecbugs-plugin', version='1.14.0')]
 )
 
 
 FB = new Plugin(groupId: 'com.github.spotbugs', artifactId: 'spotbugs', version: '4.9.3')
-CONTRIB = new Plugin(groupId: 'com.mebigfatguy.sb-contrib', artifactId: 'sb-contrib', version: '7.6.11')
+CONTRIB = new Plugin(groupId: 'com.mebigfatguy.sb-contrib', artifactId: 'sb-contrib', version: '7.6.12')
 FSB = new Plugin(groupId: 'com.h3xstream.findsecbugs', artifactId: 'findsecbugs-plugin', version: '1.14.0')
 
 def destDir() {


### PR DESCRIPTION
When sb-contrib was updated in https://github.com/spotbugs/sonar-findbugs/pull/1297 from 7.6.11 to 7.6.12, it was not updated everywhere like in https://github.com/spotbugs/sonar-findbugs/pull/1288 when updated from 7.6.10 to 7.6.11.
[Here are the changes between 7.6.11 and 7.6.12 in fb-contrib](https://github.com/mebigfatguy/fb-contrib/compare/v7.6.11.sb...v7.6.12.sb).
There was no new rule added, and the `messages.xml` and the `findbugs.xml` haven't changed between these two versions, so if I'm not mistaken, only the `README.md` and the `BuildXmlFiles.groovy` needed to be updated.
If I missed something, please let me know.