### PR TITLE
Upgrade SpotBugs to 4.9.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,4 +82,4 @@ Findbugs Plugin version|Embedded SpotBugs/Findbugs version|Embedded Findsecbugs 
 4.5.0                  | 4.9.3 (SpotBugs)                 | 1.14.0                     | 7.6.10 (sb-contrib)        |  17|9.9-25.5|8.0.1.36337
 4.5.1                  | 4.9.3 (SpotBugs)                 | 1.14.0                     | 7.6.10 (sb-contrib)        |  17|9.9~|8.0.1.36337
 4.5.2                  | 4.9.3 (SpotBugs)                 | 1.14.0                     | 7.6.10 (sb-contrib)        |  17|9.9~|8.0.1.36337
-4.5.3-SNAPSHOT         | 4.9.4 (SpotBugs)                 | 1.14.0                     | 7.6.14 (sb-contrib)        |  17|9.9~|8.0.1.36337
+4.5.3-SNAPSHOT         | 4.9.5 (SpotBugs)                 | 1.14.0                     | 7.6.14 (sb-contrib)        |  17|9.9~|8.0.1.36337

--- a/generate_profiles/BuildXmlFiles.groovy
+++ b/generate_profiles/BuildXmlFiles.groovy
@@ -8,13 +8,13 @@ import groovy.json.JsonSlurper;
 
 @Grapes([
 
-    @Grab(group='com.github.spotbugs', module='spotbugs', version='4.9.4'),
+    @Grab(group='com.github.spotbugs', module='spotbugs', version='4.9.5'),
     @Grab(group='com.mebigfatguy.sb-contrib', module='sb-contrib', version='7.6.14'),
     @Grab(group='com.h3xstream.findsecbugs' , module='findsecbugs-plugin', version='1.14.0')]
 )
 
 
-FB = new Plugin(groupId: 'com.github.spotbugs', artifactId: 'spotbugs', version: '4.9.4')
+FB = new Plugin(groupId: 'com.github.spotbugs', artifactId: 'spotbugs', version: '4.9.5')
 CONTRIB = new Plugin(groupId: 'com.mebigfatguy.sb-contrib', artifactId: 'sb-contrib', version: '7.6.14')
 FSB = new Plugin(groupId: 'com.h3xstream.findsecbugs', artifactId: 'findsecbugs-plugin', version: '1.14.0')
 

--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
       Also need to update profiles, see ./generate_profiles/README.md for detail.
       Update the version table and the rules count badge in README.md
     -->
-    <spotbugs.version>4.9.4</spotbugs.version>
+    <spotbugs.version>4.9.5</spotbugs.version>
     <sbcontrib.version>7.6.14</sbcontrib.version>
     <findsecbugs.version>1.14.0</findsecbugs.version>
 

--- a/src/main/resources/org/sonar/plugins/findbugs/rules-findbugs.xml
+++ b/src/main/resources/org/sonar/plugins/findbugs/rules-findbugs.xml
@@ -2004,7 +2004,7 @@ threads may be synchronizing on different objects.&lt;/p&gt;
     <name>Malicious code - Field should be moved out of an interface and made package protected</name>
     <configKey>MS_OOI_PKGPROTECT</configKey>
     <description>&lt;p&gt;
- A final static field that is
+ A static final field that is
 defined in an interface references a mutable
    object such as an array or hashtable.
    This mutable object could
@@ -2072,7 +2072,7 @@ could be changed by malicious code or
   <rule key='MS_MUTABLE_HASHTABLE' priority='INFO'>
     <name>Malicious code - Field is a mutable Hashtable</name>
     <configKey>MS_MUTABLE_HASHTABLE</configKey>
-    <description>&lt;p&gt;A final static field references a Hashtable
+    <description>&lt;p&gt;A static final field references a Hashtable
    and can be accessed by malicious code or
         by accident from another package.
    This code can freely modify the contents of the Hashtable.&lt;/p&gt;</description>
@@ -2081,7 +2081,7 @@ could be changed by malicious code or
   <rule key='MS_MUTABLE_COLLECTION' priority='INFO'>
     <name>Malicious code - Field is a mutable collection</name>
     <configKey>MS_MUTABLE_COLLECTION</configKey>
-    <description>&lt;p&gt;A mutable collection instance is assigned to a final static field,
+    <description>&lt;p&gt;A mutable collection instance is assigned to a static final field,
    thus can be changed by malicious code or by accident from another package.
    Consider wrapping this field into Collections.unmodifiableSet/List/Map/etc.
    to avoid this vulnerability.&lt;/p&gt;</description>
@@ -2090,7 +2090,7 @@ could be changed by malicious code or
   <rule key='MS_MUTABLE_COLLECTION_PKGPROTECT' priority='INFO'>
     <name>Malicious code - Field is a mutable collection which should be package protected</name>
     <configKey>MS_MUTABLE_COLLECTION_PKGPROTECT</configKey>
-    <description>&lt;p&gt;A mutable collection instance is assigned to a final static field,
+    <description>&lt;p&gt;A mutable collection instance is assigned to a static final field,
    thus can be changed by malicious code or by accident from another package.
    The field could be made package protected to avoid this vulnerability.
    Alternatively you may wrap this field into Collections.unmodifiableSet/List/Map/etc.
@@ -2100,7 +2100,7 @@ could be changed by malicious code or
   <rule key='MS_MUTABLE_ARRAY' priority='INFO'>
     <name>Malicious code - Field is a mutable array</name>
     <configKey>MS_MUTABLE_ARRAY</configKey>
-    <description>&lt;p&gt; A final static field references an array
+    <description>&lt;p&gt; A static final field references an array
    and can be accessed by malicious code or
         by accident from another package.
    This code can freely modify the contents of the array.&lt;/p&gt;</description>


### PR DESCRIPTION
SpotBugs [4.9.5](https://github.com/spotbugs/spotbugs/releases/tag/4.9.5) is released, this PR on top of https://github.com/spotbugs/sonar-findbugs/pull/1320 updates the readme and the `generate_profiles/BuildXmlFiles.groovy` file, and ran the groovy file resulting in the change in `rules-findbugs.xml`.