### PR TITLE
modify cert tag criteria because of sei cert standard website change

### DIFF
--- a/generate_profiles/BuildXmlFiles.groovy
+++ b/generate_profiles/BuildXmlFiles.groovy
@@ -202,7 +202,7 @@ def writeRules(String rulesSetName,List<Plugin> plugins,List<String> includedBug
                     if (pattern.Details.text().toLowerCase().contains('cwe')) {
                         tag("cwe")
                     }
-                    if (pattern.Details.text().toLowerCase().contains('wiki.sei.cmu.edu')) {
+                    if (pattern.Details.text().toLowerCase().contains('wiki.sei.cmu.edu') || pattern.Details.text().toLowerCase().contains('cmu-sei.github.io')) {
 						tag('cert')
 					}
                     if (pattern.ShortDescription.text().toLowerCase().contains('android')) {


### PR DESCRIPTION
The SEI Cert Standard got migrated to a new website. This PR changes the criteria to the `cert` tag to follow this change.