### PR TITLE
Release 4.7.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,4 +83,5 @@ Findbugs Plugin version|Embedded SpotBugs/Findbugs version|Embedded Findsecbugs 
 4.5.1                  | 4.9.3 (SpotBugs)                 | 1.14.0                     | 7.6.10 (sb-contrib)        |  17|9.9~|8.0.1.36337
 4.5.2                  | 4.9.3 (SpotBugs)                 | 1.14.0                     | 7.6.10 (sb-contrib)        |  17|9.9~|8.0.1.36337
 4.6.0                  | 4.9.8 (SpotBugs)                 | 1.14.0                     | 7.6.15 (sb-contrib)        |  17|9.9~|8.0.1.36337
-4.6.1-SNAPSHOT         | 4.10.3 (SpotBugs)                 | 1.14.0                     | 7.7.4 (sb-contrib)        |  17|9.9~|8.0.1.36337
+4.7.0                  | 4.10.3 (SpotBugs)                | 1.14.0                     | 7.7.4 (sb-contrib)        |  17|9.9~|8.0.1.36337
+4.7.1-SNAPSHOT         | 4.10.3 (SpotBugs)                | 1.14.0                     | 7.7.4 (sb-contrib)        |  17|9.9~|8.0.1.36337

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>com.github.spotbugs</groupId>
   <artifactId>sonar-findbugs-plugin</artifactId>
-  <version>4.7.0</version>
+  <version>4.7.1-SNAPSHOT</version>
   <packaging>sonar-plugin</packaging>
 
   <name>SonarQube SpotBugs Plugin</name>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>com.github.spotbugs</groupId>
   <artifactId>sonar-findbugs-plugin</artifactId>
-  <version>4.6.1-SNAPSHOT</version>
+  <version>4.7.0</version>
   <packaging>sonar-plugin</packaging>
 
   <name>SonarQube SpotBugs Plugin</name>


### PR DESCRIPTION
⚠️ To be merged, not squashed!

There were a lot of changes since the last release (see [compare 4.6.0 with master](https://github.com/spotbugs/sonar-findbugs/compare/v4.6.0...master)), so I think it's time for a new one. I couldn't find a reason to postpone it, other than @gtoison not that active here lately. Since there were quite a lot of changes, IMO it's worth to have a minor release instead of a patch.

Based on the [release procedure](https://github.com/spotbugs/sonar-findbugs/blob/master/RELEASE_PROCEDURE.md) documentation and the last few releases (see below the line), as far as I can see this should be good.

----------------------
Releases in the last half year for reference:
- 4.6.0 [release](https://github.com/spotbugs/sonar-findbugs/releases/tag/v4.6.0) and [PR](https://github.com/spotbugs/sonar-findbugs/pull/1347), 
- 4.5.2 [release](https://github.com/spotbugs/sonar-findbugs/releases/tag/4.5.2) and [PR](https://github.com/spotbugs/sonar-findbugs/pull/1283), 
- 4.5.1 [release](https://github.com/spotbugs/sonar-findbugs/releases/tag/4.5.1) and [PR](https://github.com/spotbugs/sonar-findbugs/pull/1276), 
- 4.5.0 [release](https://github.com/spotbugs/sonar-findbugs/releases/tag/4.5.0) and [PR](https://github.com/spotbugs/sonar-findbugs/pull/1275), 
- 4.4.2 [release](https://github.com/spotbugs/sonar-findbugs/releases/tag/4.4.2) - could not find PR, likely pushed to master directly, 
- 4.4.1 [release](https://github.com/spotbugs/sonar-findbugs/releases/tag/4.4.1) and [PR](https://github.com/spotbugs/sonar-findbugs/pull/1182), 
- 4.4.0 [release](https://github.com/spotbugs/sonar-findbugs/releases/tag/4.4.0) and [PR](https://github.com/spotbugs/sonar-findbugs/pull/1162))